### PR TITLE
Add a batch iterator for the Vamana Indexes

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SHARED_LIBRARY_FILES
     src/vamana/search.cpp
     src/vamana/build.cpp
     src/vamana/test.cpp
+    src/vamana/iterator.cpp
     # inverted
     src/inverted/inverted.cpp
     src/inverted/memory/common.cpp

--- a/benchmark/include/svs-benchmark/benchmark.h
+++ b/benchmark/include/svs-benchmark/benchmark.h
@@ -222,8 +222,7 @@ class ExecutableDispatcher {
 // In general, index builds can take a long time and it may be beneficial to two things:
 //
 // (1) Regularly save checkpoints of results as they are generated so that if the
-// application
-//     fails, we do not lose all of our data.
+// application fails, we do not lose all of our data.
 // (2) Provide results in as near real-time as we can so we can monitor currently running
 //     processes to determine as early as possible if something has gone wrong.
 //

--- a/benchmark/include/svs-benchmark/index_traits.h
+++ b/benchmark/include/svs-benchmark/index_traits.h
@@ -26,8 +26,9 @@ template <typename Index> struct IndexTraits; //{
 //
 ///// Search Requirements
 // template<svs::data::ImmutableMemoryDataset Queries>
-// static auto search(index_type&, const Queries&, size_t num_neighbors, const
-// config_type&);
+// static auto search(
+//     index_type&, const Queries&, size_t num_neighbors, const config_type&
+// );
 //
 // template<svs::data::ImmutableMemoryDataset Queries, typename GroundTruth>
 // static config_type calibrate(
@@ -45,8 +46,9 @@ template <typename Index> struct IndexTraits; //{
 ///// Dynamic Build Requirements
 //
 // template<svs::data::ImmutableMemoryDataset Points>
-// static void add_points(index_type&, const Points& points, const std::vector<size_t>&
-// ids);
+// static void add_points(
+//     index_type&, const Points& points, const std::vector<size_t>& ids
+// );
 //
 // static void delete_points(index_type&, const std::vector<size_t>& ids);
 //

--- a/benchmark/include/svs-benchmark/search.h
+++ b/benchmark/include/svs-benchmark/search.h
@@ -144,11 +144,25 @@ template <typename T, std::integral I> struct QuerySet {
     }
 
     QuerySet(
-        const dataset_type& queries,
-        const groundtruth_type& groundtruth,
+        const svs::data::SimpleData<T>& queries,
+        const svs::data::SimpleData<I>& groundtruth,
+        size_t number_of_training_elements
+    )
+        : QuerySet{queries.cview(), groundtruth.cview(), number_of_training_elements} {}
+
+    QuerySet(
+        const svs::data::ConstSimpleDataView<T>& queries,
+        const svs::data::ConstSimpleDataView<I>& groundtruth,
         size_t number_of_training_elements
     ) {
-        assert(queries.size() == groundtruth.size());
+        size_t nqueries = queries.size();
+        if (nqueries != groundtruth.size()) {
+            throw ANNEXCEPTION(
+                "Query size ({}) and groundtruth size ({}) do not match!",
+                nqueries,
+                groundtruth.size()
+            );
+        }
         if (number_of_training_elements >= queries.size()) {
             throw ANNEXCEPTION(
                 "Number of elements to pull out into the training ({}) is greater than the "

--- a/benchmark/include/svs-benchmark/vamana/iterator.h
+++ b/benchmark/include/svs-benchmark/vamana/iterator.h
@@ -1,0 +1,534 @@
+/*
+ * Copyright 2024 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// svs-benchmark
+#include "svs-benchmark/benchmark.h"
+#include "svs-benchmark/datasets.h"
+#include "svs-benchmark/index_traits.h"
+#include "svs-benchmark/search.h"
+
+#include "svs-benchmark/vamana/static_traits.h"
+
+// svs
+#include "svs/core/distance.h"
+#include "svs/index/vamana/iterator.h"
+
+namespace svsbenchmark::vamana {
+
+/// Pre-configuration for the linear schedule.
+struct LinearSchedulePrototype {
+    size_t scale_search_window_;
+    size_t scale_buffer_capacity_;
+    int64_t enable_filter_after_;
+    size_t batch_size_start_;
+    size_t scale_batch_size_;
+    // Whether search should be restarted on every iteration.
+    bool restart_searches_;
+
+    ///// Saving and Loading.
+    static constexpr std::string_view serialization_schema =
+        "svsbench_vamana_iter_schedule";
+    static constexpr svs::lib::Version save_version{0, 0, 0};
+
+    svs::lib::SaveTable save() const {
+        return svs::lib::SaveTable{
+            serialization_schema,
+            save_version,
+            {SVS_LIST_SAVE_(scale_search_window),
+             SVS_LIST_SAVE_(scale_buffer_capacity),
+             SVS_LIST_SAVE_(enable_filter_after),
+             SVS_LIST_SAVE_(batch_size_start),
+             SVS_LIST_SAVE_(scale_batch_size),
+             SVS_LIST_SAVE_(restart_searches)}};
+    }
+
+    static LinearSchedulePrototype load(const svs::lib::ContextFreeLoadTable& table) {
+        return LinearSchedulePrototype{
+            SVS_LOAD_MEMBER_AT_(table, scale_search_window),
+            SVS_LOAD_MEMBER_AT_(table, scale_buffer_capacity),
+            SVS_LOAD_MEMBER_AT_(table, enable_filter_after),
+            SVS_LOAD_MEMBER_AT_(table, batch_size_start),
+            SVS_LOAD_MEMBER_AT_(table, scale_batch_size),
+            SVS_LOAD_MEMBER_AT_(table, restart_searches)};
+    }
+
+    // Return several representative examples for the schedule.
+    static std::vector<LinearSchedulePrototype> examples() {
+        return {{10, 20, -1, 10, 0, false}, {10, 10, 3, 10, 5, false}};
+    }
+
+    // Should search be restarted from scratch every iteration.
+    bool restart_every_iteration() const { return restart_searches_; }
+
+    // Materialize an actual schedule given a set of base parameters.
+    // NOTE: This does not propagate the `restart_searches_` flag.
+    svs::index::vamana::LinearSchedule
+    materialize(const svs::index::vamana::VamanaSearchParameters& sp) const {
+        return svs::index::vamana::LinearSchedule{
+            sp,
+            svs::lib::narrow<uint16_t>(scale_search_window_),
+            svs::lib::narrow<uint16_t>(scale_buffer_capacity_),
+            svs::lib::narrow<int16_t>(enable_filter_after_),
+            svs::lib::narrow<uint16_t>(batch_size_start_),
+            svs::lib::narrow<uint16_t>(scale_batch_size_)};
+    }
+};
+
+struct IteratorSearchParameters {
+  public:
+    ///// Members
+    // The schedules to try.
+    std::vector<LinearSchedulePrototype> schedules_;
+    // target recalls relative to base number of neighbors.
+    std::vector<svs::lib::Percent> target_recalls_;
+    // The number of batches to yield.
+    size_t num_batches_;
+    // Since iterator search is performed on a single thread, this subsample parameter
+    // provides a mechanism to operate on a reduced number of queries to reduce test time.
+    size_t query_subsample_;
+
+    ///// Saving and Loading.
+    static constexpr std::string_view serialization_schema = "svsbenchamrk_isp";
+    static constexpr svs::lib::Version save_version{0, 0, 0};
+
+    static IteratorSearchParameters example() {
+        return IteratorSearchParameters{
+            .schedules_ = LinearSchedulePrototype::examples(),
+            .target_recalls_ = {svs::lib::Percent(0.9)},
+            .num_batches_ = 5,
+            .query_subsample_ = 10,
+        };
+    }
+
+    svs::lib::SaveTable save() const {
+        return svs::lib::SaveTable{
+            serialization_schema,
+            save_version,
+            {SVS_LIST_SAVE_(schedules),
+             SVS_LIST_SAVE_(target_recalls),
+             SVS_LIST_SAVE_(num_batches),
+             SVS_LIST_SAVE_(query_subsample)}};
+    }
+
+    static IteratorSearchParameters load(const svs::lib::ContextFreeLoadTable& table) {
+        return IteratorSearchParameters{
+            SVS_LOAD_MEMBER_AT_(table, schedules),
+            SVS_LOAD_MEMBER_AT_(table, target_recalls),
+            SVS_LOAD_MEMBER_AT_(table, num_batches),
+            SVS_LOAD_MEMBER_AT_(table, query_subsample)};
+    }
+};
+
+inline constexpr std::string_view iterator_benchmark_name() { return "vamana_iterator_v1"; }
+
+std::unique_ptr<Benchmark> iterator_benchmark();
+
+// Perform a check size-reduction on the given queries and groundtruth.
+//
+// To maintain an appropriate split for training and test data, argument ``count`` must be
+template <typename Q, typename I>
+svsbenchmark::search::QuerySet<Q, I> subsample(
+    const svs::data::ConstSimpleDataView<Q>& queries,
+    const svs::data::ConstSimpleDataView<I>& groundtruth,
+    size_t count
+) {
+    if (2 * count > queries.size()) {
+        throw ANNEXCEPTION(
+            "Subsample amount {} must be at most half of the total number of queries ({}) "
+            "to provide an adequate training/test split.",
+            count,
+            queries.size()
+        );
+    }
+
+    // TODO: Provide a method to resize views.
+    return svsbenchmark::search::QuerySet<Q, I>{
+        svs::data::ConstSimpleDataView<Q>{queries.data(), 2 * count, queries.dimensions()},
+        svs::data::ConstSimpleDataView<I>{
+            groundtruth.data(), 2 * count, groundtruth.dimensions()},
+        count};
+}
+
+struct IteratorSearch {
+  public:
+    ///// Members
+    svsbenchmark::Dataset dataset_;
+    std::filesystem::path config_;
+    std::filesystem::path graph_;
+    std::filesystem::path data_;
+    std::filesystem::path queries_;
+    std::filesystem::path groundtruth_;
+    svs::DistanceType distance_;
+    IteratorSearchParameters parameters_;
+    // Types of the queries and source datasets.
+    svs::DataType query_type_;
+    Extent ndims_;
+
+    static IteratorSearch example() {
+        return IteratorSearch{
+            .dataset_ = Dataset::example(),
+            .config_ = "path/to/index/config",
+            .graph_ = "path/to/graph",
+            .data_ = "path/to/data",
+            .queries_ = "path/to/queries",
+            .groundtruth_ = "path/to/groundtruth",
+            .distance_ = svs::DistanceType::L2,
+            .parameters_ = IteratorSearchParameters::example(),
+            .query_type_ = svs::DataType::float32,
+            .ndims_ = Extent{svs::Dynamic}};
+    }
+
+    // Dispatch invocation.
+    template <typename F> auto invoke(F&& f, const Checkpoint& checkpointer) const {
+        return f(dataset_, query_type_, distance_, ndims_, checkpointer, *this);
+    }
+
+    ///// Save/Load
+    static constexpr svs::lib::Version save_version{0, 0, 0};
+    static constexpr std::string_view serialization_schema = "svsbenchmark_vamana_iterator";
+    svs::lib::SaveTable save() const {
+        return svs::lib::SaveTable(
+            serialization_schema,
+            save_version,
+            {SVS_LIST_SAVE_(dataset),
+             SVS_LIST_SAVE_(config),
+             SVS_LIST_SAVE_(graph),
+             SVS_LIST_SAVE_(data),
+             SVS_LIST_SAVE_(queries),
+             SVS_LIST_SAVE_(groundtruth),
+             SVS_LIST_SAVE_(distance),
+             SVS_LIST_SAVE_(parameters),
+             SVS_LIST_SAVE_(query_type),
+             SVS_LIST_SAVE_(ndims)}
+        );
+    }
+
+    static IteratorSearch load(
+        const svs::lib::ContextFreeLoadTable& table,
+        const std::optional<std::filesystem::path>& root = {}
+    ) {
+        return IteratorSearch{
+            .dataset_ = SVS_LOAD_MEMBER_AT_(table, dataset, root),
+            .config_ = svsbenchmark::extract_filename(table, "config", root),
+            .graph_ = svsbenchmark::extract_filename(table, "graph", root),
+            .data_ = svsbenchmark::extract_filename(table, "data", root),
+            .queries_ = svsbenchmark::extract_filename(table, "queries", root),
+            .groundtruth_ = svsbenchmark::extract_filename(table, "groundtruth", root),
+            .distance_ = SVS_LOAD_MEMBER_AT_(table, distance),
+            .parameters_ = SVS_LOAD_MEMBER_AT_(table, parameters),
+            .query_type_ = SVS_LOAD_MEMBER_AT_(table, query_type),
+            .ndims_ = SVS_LOAD_MEMBER_AT_(table, ndims)};
+    }
+};
+
+using IteratorDispatcher = svs::lib::Dispatcher<
+    toml::table,
+    Dataset,
+    svs::DataType,
+    svs::DistanceType,
+    Extent,
+    const svsbenchmark::Checkpoint&,
+    const IteratorSearch&>;
+
+/////
+///// Implementation
+/////
+
+struct YieldedResult {
+    // The invocation number of this result.
+    size_t iteration_;
+    // The number of neighbors yielded for this result.
+    size_t yielded_;
+    // The number of results yielded so far in total.
+    size_t total_yielded_;
+    // The `total_yielded_` recall at `total_yielded_`.
+    double total_recall_;
+    // Execution time for the most recent batch of results.
+    double execution_time_;
+
+    ///// Saving.
+    static constexpr std::string_view serialization_schema = "svsbenchmark_yielded_result";
+    static constexpr svs::lib::Version save_version = svs::lib::Version(0, 0, 0);
+
+    svs::lib::SaveTable save() const {
+        return svs::lib::SaveTable{
+            serialization_schema,
+            save_version,
+            {SVS_LIST_SAVE_(iteration),
+             SVS_LIST_SAVE_(yielded),
+             SVS_LIST_SAVE_(total_yielded),
+             SVS_LIST_SAVE_(total_recall),
+             SVS_LIST_SAVE_(execution_time)}};
+    }
+};
+
+// TODO: Make the dependence on `Report` looser.
+template <typename Index> struct QueryIteratorResult {
+    LinearSchedulePrototype schedule_;
+    size_t num_batches_;
+    double target_recall_;
+    search::RunReport<Index> report_;
+    // The search parameters used for each iteration.
+    // Must be the same for all queries in the batch.
+    std::vector<svs::index::vamana::VamanaSearchParameters> iteration_parameters_;
+    // Outer vector: Results for each query.
+    // Inner vector: Results within a query.
+    std::vector<std::vector<YieldedResult>> results_;
+
+    ///// Constructor
+    QueryIteratorResult(
+        const LinearSchedulePrototype& schedule,
+        double target_recall,
+        search::RunReport<Index> report,
+        std::vector<svs::index::vamana::VamanaSearchParameters> iteration_parameters,
+        std::vector<std::vector<YieldedResult>> results
+    )
+        : schedule_{schedule}
+        , num_batches_{iteration_parameters.size()}
+        , target_recall_{target_recall}
+        , report_{std::move(report)}
+        , iteration_parameters_{std::move(iteration_parameters)}
+        , results_{std::move(results)} {
+        // Ensure all the yielded results have the correct size.
+        for (size_t i = 0, imax = results_.size(); i < imax; ++i) {
+            size_t these_batches = results_.at(i).size();
+            if (results_.at(i).size() != num_batches_) {
+                throw ANNEXCEPTION(
+                    "Yielded result {} has {} batches when {} were expected.",
+                    i,
+                    these_batches,
+                    num_batches_
+                );
+            }
+        }
+    }
+
+    ///// Saving.
+    static constexpr std::string_view serialization_schema = "svsbenchmark_iterator_result";
+    static constexpr svs::lib::Version save_version = svs::lib::Version(0, 0, 0);
+
+    svs::lib::SaveTable save() const {
+        return svs::lib::SaveTable{
+            serialization_schema,
+            save_version,
+            {SVS_LIST_SAVE_(schedule),
+             SVS_LIST_SAVE_(num_batches),
+             SVS_LIST_SAVE_(target_recall),
+             SVS_LIST_SAVE_(report),
+             SVS_LIST_SAVE_(iteration_parameters),
+             SVS_LIST_SAVE_(results)}};
+    }
+};
+
+template <
+    typename Index,
+    typename QueryType,
+    typename I,
+    typename MakeIterator,
+    typename DoCheckpoint,
+    typename Extra = svsbenchmark::Placeholder>
+std::vector<QueryIteratorResult<Index>> tune_and_search_iterator(
+    Index& index,
+    const vamana::IteratorSearchParameters& parameters,
+    const svsbenchmark::search::QuerySet<QueryType, I>& query_set,
+    svsbenchmark::CalibrateContext context,
+    MakeIterator&& make_iterator,
+    const DoCheckpoint& do_checkpoint,
+    Extra&& extra = {}
+) {
+    using traits = IndexTraits<Index>;
+
+    const auto& query_test = query_set.test_set_;
+    const auto& groundtruth_test = query_set.test_set_groundtruth_;
+
+    const size_t nqueries = query_test.size();
+
+    // Loop over each batchsize.
+    auto query_iterator_results = std::vector<QueryIteratorResult<Index>>{};
+    for (const auto& schedule : parameters.schedules_) {
+        auto initial_batch_size = schedule.batch_size_start_;
+        for (auto target_recall : parameters.target_recalls_) {
+            // Calibrate the index for the given recall.
+            auto config = traits::calibrate(
+                index,
+                query_set.training_set_,
+                query_set.training_set_groundtruth_,
+                initial_batch_size,
+                target_recall.value(),
+                context,
+                extra
+            );
+
+            // Refine on the test set.
+            config = traits::calibrate_with_hint(
+                index,
+                query_set.test_set_,
+                query_set.test_set_groundtruth_,
+                initial_batch_size,
+                target_recall.value(),
+                svsbenchmark::CalibrateContext::TestSetTune,
+                config,
+                extra
+            );
+
+            // Now we have a calibrated configuration - obtain a baseline report for
+            // searching with this batchsize.
+            auto report = svsbenchmark::search::search_with_config(
+                index, config, query_test, groundtruth_test, initial_batch_size
+            );
+
+            // `resuilt_buffer`: All results that have been returned by the iterator.
+            auto result_buffer = std::vector<size_t>();
+
+            // Helper lambda to record statistics post-run.
+            // This is needed since creation of the iterator starts graph search.
+            //
+            // TODO: It might be worth exposing an API on the iterator to disable eager
+            //       searching in the constructor.
+            auto tally = [&result_buffer, &groundtruth_test](
+                             const auto& iterator,
+                             size_t query_index,
+                             size_t iteration,
+                             double execution_time
+                         ) {
+                // Populate most recent results.
+                auto iterator_results = iterator.results();
+                std::transform(
+                    iterator_results.begin(),
+                    iterator_results.end(),
+                    std::back_inserter(result_buffer),
+                    [](auto neighbor) { return neighbor.id(); }
+                );
+
+                // Compute local recalls.
+                size_t total_yielded = result_buffer.size();
+                if (groundtruth_test.dimensions() < total_yielded) {
+                    throw ANNEXCEPTION(
+                        "Groundtruth with {} entries has insufficient entries to compute "
+                        "recall for {} neighbors!",
+                        groundtruth_test.dimensions(),
+                        result_buffer.size()
+                    );
+                }
+                auto count = svs::lib::count_intersect(
+                    result_buffer,
+                    groundtruth_test.get_datum(query_index).first(total_yielded)
+                );
+
+                double recall = svs::lib::narrow_cast<double>(count) /
+                                svs::lib::narrow_cast<double>(total_yielded);
+
+                return YieldedResult{
+                    .iteration_ = iteration,
+                    .yielded_ = iterator.size(),
+                    .total_yielded_ = total_yielded,
+                    .total_recall_ = recall,
+                    .execution_time_ = execution_time};
+            };
+
+            // Now that we have the baseline, obtain iterator based results.
+            auto iteration_parameters =
+                std::vector<svs::index::vamana::VamanaSearchParameters>();
+            auto yielded_results = std::vector<std::vector<YieldedResult>>();
+            for (size_t i = 0; i < nqueries; ++i) {
+                result_buffer.clear();
+                auto& timings_for_this_query = yielded_results.emplace_back();
+                auto&& query = query_test.get_datum(i);
+
+                // The first call to `iterator` kick-starts graph search.
+                auto tic = svs::lib::now();
+                auto iterator = make_iterator(index, query, config, schedule);
+                auto elapsed = svs::lib::time_difference(tic);
+                if (i == 0) {
+                    iteration_parameters.push_back(iterator.parameters_for_current_batch());
+                }
+
+                timings_for_this_query.push_back(tally(iterator, i, 0, elapsed));
+                for (size_t j = 0; j < parameters.num_batches_; ++j) {
+                    // If requested by the parent schedule, reset search for this
+                    // iteration.
+                    if (schedule.restart_every_iteration()) {
+                        iterator.restart_next_search();
+                    }
+
+                    tic = svs::lib::now();
+                    iterator.next();
+                    elapsed = svs::lib::time_difference(tic);
+                    timings_for_this_query.push_back(tally(iterator, i, j + 1, elapsed));
+                    if (i == 0) {
+                        iteration_parameters.push_back(
+                            iterator.parameters_for_current_batch()
+                        );
+                    }
+                }
+            }
+
+            // Finish up summarizing these results.
+            query_iterator_results.emplace_back(
+                schedule,
+                target_recall.value(),
+                std::move(report),
+                std::move(iteration_parameters),
+                std::move(yielded_results)
+            );
+            do_checkpoint(query_iterator_results);
+        }
+    }
+    return query_iterator_results;
+}
+
+template <typename Index, typename QueryType, typename I>
+toml::table tune_and_search_iterator(
+    Index& index,
+    const IteratorSearch& job,
+    const svsbenchmark::search::QuerySet<QueryType, I>& query_set,
+    const svsbenchmark::Checkpoint& checkpointer
+) {
+    // pre-lower the IteratorSearch for checkpointing purposes.
+    auto toml_base = svs::lib::save_to_table(job);
+
+    // Use a helper lambda to save the results.
+    // This lambda can be reused when generating the final ``toml::table`` to ensure the
+    // layout is the same.
+    auto serialize_results = [&](const std::vector<QueryIteratorResult<Index>>&
+                                     results_so_far) {
+        return toml::table{{"job", toml_base}, {"results", svs::lib::save(results_so_far)}};
+    };
+
+    auto do_checkpoint = [&](const std::vector<QueryIteratorResult<Index>>& results_so_far
+                         ) {
+        checkpointer.checkpoint(
+            serialize_results(results_so_far), iterator_benchmark_name()
+        );
+    };
+
+    auto results = tune_and_search_iterator(
+        index,
+        job.parameters_,
+        query_set,
+        svsbenchmark::CalibrateContext::InitialTrainingSet,
+        [](const auto& index, const auto& query, const auto& config, const auto& schedule) {
+            return index.batch_iterator(query, schedule.materialize(config));
+        },
+        do_checkpoint,
+        svsbenchmark::IndexTraits<Index>::regression_optimization()
+    );
+    return serialize_results(results);
+}
+
+} // namespace svsbenchmark::vamana

--- a/benchmark/include/svs-benchmark/vamana/static_traits.h
+++ b/benchmark/include/svs-benchmark/vamana/static_traits.h
@@ -18,6 +18,7 @@
 
 // svs-benchmark
 #include "svs-benchmark/index_traits.h"
+#include "svs-benchmark/vamana/search.h"
 
 // svs
 #include "svs/orchestrators/vamana.h"
@@ -29,6 +30,7 @@
 namespace svsbenchmark {
 
 template <> struct IndexTraits<svs::Vamana> {
+    using index_type = svs::Vamana;
     using config_type = svs::index::vamana::VamanaSearchParameters;
     using state_type = svsbenchmark::vamana::VamanaState;
     using calibration_constructor =
@@ -61,13 +63,13 @@ template <> struct IndexTraits<svs::Vamana> {
     static std::string name() { return "static vamana index (type erased)"; }
 
     // Configuration Space.
-    static void apply_config(svs::Vamana& index, const config_type& config) {
+    static void apply_config(index_type& index, const config_type& config) {
         index.set_search_parameters(config);
     }
 
     template <svs::data::ImmutableMemoryDataset Queries>
     static auto search(
-        svs::Vamana& index,
+        index_type& index,
         const Queries& queries,
         size_t num_neighbors,
         const config_type& config
@@ -76,12 +78,12 @@ template <> struct IndexTraits<svs::Vamana> {
         return index.search(queries, num_neighbors);
     }
 
-    static state_type report_state(const svs::Vamana& index) { return state_type(index); }
+    static state_type report_state(const index_type& index) { return state_type(index); }
 
     // Calibrate from scratch
     template <svs::data::ImmutableMemoryDataset Queries, typename Groundtruth>
     static config_type calibrate(
-        svs::Vamana& index,
+        index_type& index,
         const Queries& queries,
         const Groundtruth& groundtruth,
         size_t num_neighbors,
@@ -104,7 +106,7 @@ template <> struct IndexTraits<svs::Vamana> {
     // Calibrate with hint.
     template <svs::data::ImmutableMemoryDataset Queries, typename Groundtruth>
     static config_type calibrate_with_hint(
-        svs::Vamana& index,
+        index_type& index,
         const Queries& queries,
         const Groundtruth& groundtruth,
         size_t num_neighbors,
@@ -133,5 +135,4 @@ template <> struct IndexTraits<svs::Vamana> {
         );
     }
 };
-
 } // namespace svsbenchmark

--- a/benchmark/include/svs-benchmark/vamana/uncompressed.h
+++ b/benchmark/include/svs-benchmark/vamana/uncompressed.h
@@ -18,6 +18,7 @@
 
 // svs-benchmark
 #include "svs-benchmark/vamana/build.h"
+#include "svs-benchmark/vamana/iterator.h"
 #include "svs-benchmark/vamana/search.h"
 #include "svs-benchmark/vamana/test.h"
 
@@ -29,6 +30,9 @@ namespace svsbenchmark::vamana {
 ///// target-registration
 // search
 void register_uncompressed_static_search(vamana::StaticSearchDispatcher&);
+
+// iterator
+void register_uncompressed_iterator_search(vamana::IteratorDispatcher&);
 
 // build
 void register_uncompressed_static_build(vamana::StaticBuildDispatcher&);

--- a/benchmark/src/main.cpp
+++ b/benchmark/src/main.cpp
@@ -19,6 +19,7 @@
 #include "svs-benchmark/datasets.h"
 // vamana
 #include "svs-benchmark/vamana/build.h"
+#include "svs-benchmark/vamana/iterator.h"
 #include "svs-benchmark/vamana/search.h"
 #include "svs-benchmark/vamana/test.h"
 // inverted
@@ -39,6 +40,7 @@ svsbenchmark::ExecutableDispatcher build_dispatcher() {
     dispatcher.register_executable(svsbenchmark::vamana::static_workflow());
     dispatcher.register_executable(svsbenchmark::vamana::dynamic_workflow());
     dispatcher.register_executable(svsbenchmark::vamana::test_generator());
+    dispatcher.register_executable(svsbenchmark::vamana::iterator_benchmark());
     // inverted
     svsbenchmark::inverted::register_executables(dispatcher);
     // documentation

--- a/benchmark/src/vamana/iterator.cpp
+++ b/benchmark/src/vamana/iterator.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2024 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// svs-benchmark
+#include "svs-benchmark/vamana/iterator.h"
+#include "svs-benchmark/benchmark.h"
+#include "svs-benchmark/datasets/uncompressed.h"
+#include "svs-benchmark/executable.h"
+#include "svs-benchmark/vamana/search.h"
+
+// implementation headers
+#include "svs-benchmark/vamana/uncompressed.h"
+
+// svs
+#include "svs/core/graph.h"
+#include "svs/index/vamana/index.h"
+#include "svs/index/vamana/iterator.h"
+#include "svs/lib/saveload.h"
+#include "svs/orchestrators/vamana.h"
+#include "svs/third-party/toml.h"
+
+// third-party
+#include "fmt/core.h"
+#include "fmt/ranges.h"
+
+// stl
+#include <algorithm>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <optional>
+
+namespace svsbenchmark::vamana {
+namespace {
+
+constexpr std::string_view HELP = R"(
+Run an iterator search benchmark using the Vamana index.
+
+Usage:
+    (1) src-file.toml (output-file.toml/--validate) [basename]
+    (2) --help
+    (3) --example
+
+1. Run all the benchmarks in the global `{}` array in `src-file.toml`.
+   All elements in the array must be parseable as a ``svsbenchmark::vamana::IteratorSearch``.
+
+   Results will be saved to `output-file.toml`.
+
+   If `--validate` is given as the second argument, then all pre-run checks will be
+   performed on the input file and arguments but not benchmark will actually be run.
+
+   Optional third argument `basename` will be used as the root for all file paths parsed.
+
+2. Print this help message.
+
+3. Display an example input TOML file to `stdout`.
+
+Backend specializations are dispatched on the following fields of the input TOML file:
+* build_type: The dataset type to use.
+* query_type: The element type of the query dataset.
+* data_type: The input type of the source dataset.
+* distance: The distance function to use.
+* ndims: The compile-time dimensionality.
+
+Compiled specializations are listed below:
+{{build_type, query_type, data_type, distance, ndims}}
+)";
+
+struct Exe {
+  public:
+    using job_type = vamana::IteratorSearch;
+    using dispatcher_type = vamana::IteratorDispatcher;
+
+    static dispatcher_type dispatcher() {
+        auto dispatcher = dispatcher_type{};
+        svsbenchmark::vamana::register_uncompressed_iterator_search(dispatcher);
+        return dispatcher;
+    }
+
+    static std::string_view name() { return vamana::iterator_benchmark_name(); }
+
+    static void print_help() {
+        fmt::print(HELP, name());
+        auto f = dispatcher();
+        for (size_t i = 0; i < f.size(); ++i) {
+            auto dispatch_strings = std::array<std::string, 5>{
+                f.description(i, 0),
+                f.description(i, 1),
+                f.description(i, 2),
+                f.description(i, 3),
+                f.description(i, 4),
+            };
+            fmt::print("{{ {} }}\n", fmt::join(dispatch_strings, ", "));
+        }
+    }
+
+    static job_type example() { return job_type::example(); }
+
+    template <typename F>
+    static std::optional<std::vector<job_type>>
+    parse_args_and_invoke(F&& f, std::span<const std::string_view> args) {
+        auto root = std::optional<std::filesystem::path>();
+        if (args.size() == 1) {
+            root = std::filesystem::path(args[0]);
+        }
+        return f(root);
+    }
+};
+} // namespace
+
+// Return an executor for this benchmark.
+std::unique_ptr<Benchmark> iterator_benchmark() {
+    return std::make_unique<JobBasedExecutable<Exe>>();
+}
+} // namespace svsbenchmark::vamana

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -36,6 +36,7 @@ endfunction()
 # Examples
 create_simple_example(saveload test_saveload saveload.cpp)
 create_simple_example(types test_types types.cpp)
+create_simple_example(vamana_iterator test_vamana_iterator vamana_iterator.cpp)
 
 ## More complicated examples involving more extensive setup.
 

--- a/examples/cpp/vamana_iterator.cpp
+++ b/examples/cpp/vamana_iterator.cpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2024 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! [Example All]
+
+//! [Includes]
+// SVS Dependencies
+#include "svs/orchestrators/vamana.h" // bulk of the dependencies required.
+
+// Alternative main definition
+#include "svsmain.h"
+
+// stl
+#include <string>
+#include <string_view>
+#include <vector>
+//! [Includes]
+
+void check(bool value, std::string_view expr, svs::lib::detail::LineInfo linfo) {
+    if (!value) {
+        throw svs::lib::ANNException(
+            "expression \"{}\" evaluated to false in {}", expr, linfo
+        );
+    }
+}
+
+#define CHECK(expr) check(expr, #expr, SVS_LINEINFO);
+
+//! [Example Index Construction]
+[[nodiscard]] svs::Vamana make_example_index() {
+    // Build the index.
+    auto build_parameters = svs::index::vamana::VamanaBuildParameters{
+        1.2, // alpha
+        16,  // graph_max_degree
+        32,  // window_size
+        16,  // max_candidate_pool_size
+        16,  // prune_to
+        true // use_full_search_history
+    };
+
+    // Create a dataset with 7 elements, each with 4 dimensions.
+    // The contents of the dataset are
+    // {0, 0, 0, 0}
+    // {1, 1, 1, 1}
+    // ...
+    // {6, 6, 6, 6}
+    auto data = svs::data::SimpleData<float>(7, 4);
+
+    // Fill data `i` with all `i`s.
+    auto buffer = std::vector<float>();
+    for (size_t i = 0; i < data.size(); ++i) {
+        auto fi = svs::lib::narrow<float>(i);
+        buffer = {fi, fi, fi, fi};
+        data.set_datum(i, buffer);
+    }
+
+    // Build the index.
+    return svs::Vamana::build<float>(build_parameters, std::move(data), svs::DistanceL2{});
+}
+//! [Example Index Construction]
+
+void demonstrate_default_schedule() {
+    //! [Setup]
+    auto index = make_example_index();
+
+    // Base search parameters for the iterator schedule.
+    // This uses a search window size/capacity of 4.
+    auto base_parameters = svs::index::vamana::VamanaSearchParameters{}.buffer_config({4});
+
+    // The default schedule take base parameters and a batch size.
+    // Each iteration will yield 3 elements that have not been yielded previously.
+    size_t batchsize = 3;
+    auto schedule = svs::index::vamana::DefaultSchedule{base_parameters, batchsize};
+
+    // Create a batch iterator over the index for the query.
+    // After the constructor returns, the contents of the first batch will be available.
+    auto itr = [&]() {
+        // Construct a query a query in a scoped block to demonstrate that the iterator
+        // maintains an internal copy.
+        auto query = std::vector<float>{3.25, 3.25, 3.25, 3.25};
+
+        // Make a batch iterator for the query using the provided schedule.
+        return index.batch_iterator(svs::lib::as_const_span(query), schedule);
+    }();
+    //! [Setup]
+
+    //! [Initial Checks]
+    // The iterator was configured to yield three neighbors on each invocation.
+    // This information is available through the `size()` method.
+    CHECK(itr.size() == 3);
+
+    // The contents of the iterator are for batch 0.
+    CHECK(itr.batch() == 0);
+
+    // Obtain a view of the current list candidates.
+    std::span<const svs::Neighbor<size_t>> results = itr.results();
+    CHECK(results.size() == 3);
+
+    // We constructed the dataset in such a way that we know what the results should be.
+    fmt::print("Neighbor 0 = {}\n", results[0].id());
+    fmt::print("Neighbor 1 = {}\n", results[1].id());
+    fmt::print("Neighbor 2 = {}\n", results[2].id());
+    CHECK(!itr.done());
+    CHECK(results[0].id() == 3);
+    CHECK(results[1].id() == 4);
+    CHECK(results[2].id() == 2);
+    //! [Initial Checks]
+
+    //! [Next Iteration]
+    // Once we've finished with the current batch of neighbors, we can step the iterator
+    // to the next batch.
+    //
+    // Using the `DefaultSchedule`, we will retrieve at most 3 new candidates.
+    itr.next();
+    CHECK(itr.size() == 3);
+
+    // The contents of the iterator are for batch 1.
+    CHECK(itr.batch() == 1);
+
+    // Update and inspect the results.
+    results = itr.results();
+    fmt::print("Neighbor 3 = {}\n", results[0].id());
+    fmt::print("Neighbor 4 = {}\n", results[1].id());
+    fmt::print("Neighbor 5 = {}\n", results[2].id());
+    CHECK(!itr.done());
+    CHECK(results[0].id() == 5);
+    CHECK(results[1].id() == 1);
+    CHECK(results[2].id() == 6);
+    //! [Next Iteration]
+
+    //! [Final Iteration]
+    // So far, the iterator has yielded 6 of the 7 vectors in the dataset.
+    // This call to `next()` should only yield a single neighbor - the last on in the index.
+    itr.next();
+    CHECK(itr.size() == 1);
+    CHECK(itr.done());
+    results = itr.results();
+    fmt::print("Neighbor 6 = {}\n", results[0].id());
+    CHECK(results[0].id() == 0);
+    //! [Final Iteration]
+
+    //! [Beyond Final Iteration]
+    // Calling `next()` again should yield no more candidates.
+    itr.next();
+    CHECK(itr.size() == 0);
+    CHECK(itr.done());
+    //! [Beyond Final Iteration]
+}
+
+// Alternative main definition
+int svs_main(std::vector<std::string> SVS_UNUSED(args)) {
+    demonstrate_default_schedule();
+    return 0;
+}
+
+SVS_DEFINE_MAIN();
+//! [Example All]

--- a/include/svs/core/graph/graph.h
+++ b/include/svs/core/graph/graph.h
@@ -269,6 +269,10 @@ template <std::unsigned_integral Idx, data::MemoryDataset Data> class SimpleGrap
     const data_type& get_data() const { return data_; }
     data_type& get_data() { return data_; }
 
+    // Resizeable API
+    void unsafe_resize(size_t new_size) { data_.resize(new_size); }
+    void add_node() { unsafe_resize(n_nodes() + 1); }
+
     ///// Saving
     static constexpr lib::Version save_version = lib::Version(0, 0, 0);
     static constexpr std::string_view serialization_schema = "default_graph";
@@ -394,10 +398,6 @@ class SimpleBlockedGraph
 
     explicit SimpleBlockedGraph(parent_type&& parent)
         : parent_type(std::move(parent)) {}
-
-    // Resizeable API
-    void unsafe_resize(size_t new_size) { (parent_type::data_).resize(new_size); }
-    void add_node() { unsafe_resize(parent_type::n_nodes() + 1); }
 
     ///// Loading
     static constexpr SimpleBlockedGraph load(const lib::LoadTable& table) {

--- a/include/svs/index/vamana/extensions.h
+++ b/include/svs/index/vamana/extensions.h
@@ -285,6 +285,22 @@ DefaultBuildAdaptor<Distance> svs_invoke(
 ///// SEARCH EXTENSIONS
 /////
 
+// Temporary customization to disable single-search for a given dataset type.
+template <typename Data>
+SVS_TEMPORARY_DISABLE_SINGLE_SEARCH struct TemporaryDisableSingleSearch {
+    [[nodiscard]] inline constexpr bool operator()() const {
+        if constexpr (svs::svs_invocable<TemporaryDisableSingleSearch>) {
+            return svs::svs_invoke(*this);
+        } else {
+            return false;
+        }
+    }
+};
+
+template <typename Data>
+SVS_TEMPORARY_DISABLE_SINGLE_SEARCH inline constexpr TemporaryDisableSingleSearch<Data>
+    temporary_disable_single_search{};
+
 /// Preprartion steps for single search.
 struct VamanaSingleSearchSetupType {
     template <typename Data, typename Distance>

--- a/include/svs/index/vamana/iterator.h
+++ b/include/svs/index/vamana/iterator.h
@@ -1,0 +1,387 @@
+/*
+ * Copyright 2024 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// svs
+#include "svs/index/index.h"
+#include "svs/index/vamana/dynamic_index.h"
+#include "svs/index/vamana/index.h"
+#include "svs/index/vamana/iterator_schedule.h"
+#include "svs/lib/scopeguard.h"
+
+// stl
+#include <unordered_set>
+#include <vector>
+
+namespace svs::index::vamana {
+
+/// A graph search initializer that uses the original contents of the search buffer
+/// to kick-start the next round of graph search.
+///
+/// If a previous search exited with an exception, then we need to be able to restart search
+/// from scratch using the traditional method.
+template <std::integral I> struct RestartInitializer {
+    template <
+        typename Buffer,
+        typename Computer,
+        graphs::ImmutableMemoryGraph Graph,
+        typename Builder>
+    void operator()(
+        Buffer& buffer,
+        const Computer& computer,
+        const Graph& graph,
+        const Builder& builder,
+        vamana::NullTracker tracker // Compile error for non-NullTracker.
+    ) const {
+        // Start again from scratch if requested.
+        if (hard_restart_) {
+            vamana::EntryPointInitializer<I>{
+                entry_points_}(buffer, computer, graph, builder, tracker);
+            return;
+        }
+
+        // Happy path - we can reuse the contents of the search buffer.
+        buffer.soft_clear();
+    }
+
+    // Entry Points in case we need to restart from scratch.
+    std::span<const I> entry_points_;
+    bool hard_restart_;
+};
+
+/////
+///// Concrete Schedules
+/////
+
+namespace detail {
+constexpr void checkdims(size_t query_size, size_t index_dims) {
+    if (query_size != index_dims) {
+        throw ANNEXCEPTION(
+            "Incompatible dimensions. Query has {} while the index expectes {}.",
+            query_size,
+            index_dims
+        );
+    }
+}
+} // namespace detail
+
+template <typename Index, typename QueryType, IteratorSchedule Schedule = DefaultSchedule>
+class BatchIterator {
+  public:
+    static_assert(
+        std::is_trivially_copyable_v<QueryType>,
+        "The batch iterator requires a trivial (no-throw copy constructible) type to "
+        "provide its exception guarentees"
+    );
+
+    // Public type-aliases
+    using scratchspace_type = index::scratchspace_t<Index>;
+    using internal_id_type = typename Index::internal_id_type;
+    using external_id_type = size_t;
+
+    /// @brief The value yielded by this container's iterator interface.
+    using value_type = Neighbor<external_id_type>;
+
+  private:
+    // Private type-aliases
+    using result_buffer_type = std::vector<value_type>;
+
+    // Clear the results buffer and copy into it the contents of the scratch buffer.
+    void copy_from_scratch(size_t max_candidates) {
+        results_.clear();
+        const auto& buffer = scratchspace_.buffer;
+        for (size_t i = 0, imax = buffer.size(); i < imax; ++i) {
+            auto neighbor = buffer[i];
+            // Unfortunately, lambdas cannot capture structured bindings.
+            // So we need to manually unpack the result from `insert`.
+            auto result = yielded_.insert(neighbor.id());
+            if (result.second /*inserted*/) {
+                // If push_back throws - rollback the insertion into the `yielded` set.
+                auto guard = lib::make_dismissable_scope_guard([&]() noexcept {
+                    // `std::unordered_set` documented to not throw exceptions on `erase`.
+                    yielded_.erase(result.first);
+                });
+                results_.push_back(adapt(neighbor));
+                guard.dismiss();
+            }
+
+            // Break if we've yielded the requested number of candidates.
+            if (results_.size() == max_candidates) {
+                break;
+            }
+        }
+    }
+
+  public:
+    using size_type = typename result_buffer_type::size_type;
+    using reference = value_type&;
+    using const_reference = const value_type&;
+
+    /// A random-access, contiguous iterator to ``value_type`` over the current batch of
+    /// results.
+    using iterator = typename result_buffer_type::iterator;
+    /// A random-access, contiguous iterator to ``cosnt value_type`` over the current batch
+    /// of results.
+    using const_iterator = typename result_buffer_type::const_iterator;
+
+    BatchIterator(const Index& parent, std::span<const QueryType> query, Schedule schedule)
+        : parent_{&parent}
+        , query_{query.begin(), query.end()}
+        , scratchspace_{parent.scratchspace()}
+        , schedule_{std::move(schedule)} {
+        // TODO: Can we delegate the dimensionality check to the index?
+        detail::checkdims(query.size(), parent.dimensions());
+
+        // Update the newly allocated scratchspace with the search parameters for the first
+        // iteration.
+        size_t max_candidates = schedule_.max_candidates(0);
+        scratchspace_.apply(schedule_.for_iteration(0));
+
+        // Perform a traditional graph search to initialize the internal scratchspace.
+        // The internal state of the scratch space is preserved for reuse on future runs.
+        parent.search(lib::as_const_span(query_), scratchspace_);
+        copy_from_scratch(max_candidates);
+    }
+
+    void update(std::span<const QueryType> newquery) { update(newquery, schedule_); }
+
+    void update(std::span<const QueryType> newquery, const Schedule& new_schedule) {
+        detail::checkdims(newquery.size(), parent_->dimensions());
+        assert(newquery.size() == query_.size());
+
+        // Perform the initial search.
+        // Make sure it completes successfully before updating local state to provide
+        // a basic exception guarenteee.
+
+        // We're reusing the scratchspace to conduct the new search.
+        // If search fails and the caller retries `next` with the previous query, we will
+        // need to completely restart search.
+        restart_search_ = true;
+        size_t max_candidates = new_schedule.max_candidates(0);
+        scratchspace_.apply(schedule_.for_iteration(0));
+        parent_->search(newquery, scratchspace_);
+
+        // Use the copy-and-swap idiom for the new schedule to support copy-constructors
+        // that can throw.
+        //
+        // If ``update`` is called with the original schedule, then we don't need to update.
+        bool schedule_needs_update = &new_schedule != &schedule_;
+        if (schedule_needs_update) {
+            if constexpr (std::is_nothrow_copy_assignable_v<Schedule>) {
+                schedule_ = new_schedule;
+            } else {
+                // Schedules are required to be nothrow swappable.
+                // Copy-construction can throw, but throwing here is still okay.
+                auto tmp = new_schedule;
+                using std::swap;
+                swap(schedule_, tmp);
+            }
+        }
+
+        // At this point - search is successful. We're committed to updating the query.
+        // Copy should not throw as long as the QueryType is trivially copyable.
+        std::copy(newquery.begin(), newquery.end(), query_.begin());
+
+        // Clearing data structures should not throw.
+        iteration_ = 0;
+        yielded_.clear();
+        copy_from_scratch(max_candidates);
+        restart_search_ = false;
+
+        // Schedules must be no-throw copy assignable.
+        schedule_ = new_schedule;
+    }
+
+    // Hook to perform late index translation.
+    // TODO: The dynamic index *really* needs a better interface for this.
+    template <NeighborLike N> svs::Neighbor<external_id_type> adapt(N internal) const {
+        if constexpr (Index::needs_id_translation) {
+            return Neighbor<external_id_type>{
+                parent_->translate_internal_id(internal.id()), internal.distance()};
+        } else {
+            return internal;
+        }
+    }
+
+    /// Return an iterator to the beginning.
+    iterator begin() { return results_.begin(); }
+    /// Return an iterato to the end.
+    iterator end() { return results_.end(); }
+    /// @copydoc begin()
+    const_iterator begin() const { return results_.begin(); }
+    /// @copydoc end()
+    const_iterator end() const { return results_.end(); }
+    /// @copydoc begin()
+    const_iterator cbegin() const { return results_.cbegin(); }
+    /// @copydoc begin()
+    const_iterator cend() const { return results_.cend(); }
+
+    /// @brief Return a span over the current batch of neighbors.
+    ///
+    /// The return span will be invalidated by calls to ``next()``.
+    std::span<const value_type> contents() const { return lib::as_const_span(results_); }
+
+    /// @brief Return the number of buffered results.
+    size_t size() const { return results_.size(); }
+
+    /// @brief Return the current batch number contained in the buffer.
+    size_t batch() const { return iteration_; }
+
+    /// @brief Return whether the entire entries in the index have been yielded.
+    ///
+    /// The transition from not done to done will be triggered by a call to ``next()``.
+    /// The contents of ``batch()`` and ``parameters_for_current_iteration()`` will then
+    /// remain unchanged by subsequent invocations of ``next()``.
+    bool done() const { return yielded_.size() == parent_->size(); }
+
+    /// @brief Require that the next iteration start search from scratch.
+    ///
+    /// This method is mainly used for testing purposes and to identify possible issues
+    /// related to maintaining state in the internal scratchspace.
+    ///
+    /// The assignment is only valid for the next invocation of `next`, after which the
+    /// default behavior of the `BatchIterator` is restored.
+    void restart_next_search() { restart_search_ = true; }
+
+    /// @brief Return a const-ref to the underlying schedule.
+    const Schedule& schedule() const { return schedule_; }
+
+    /// @brief Return a mutable reference to the underlying schedule
+    Schedule& schedule() { return schedule_; }
+
+    /// @brief Return the parameters used for the most recent iteration.
+    vamana::VamanaSearchParameters parameters_for_current_iteration() const {
+        return schedule_.for_iteration(iteration_);
+    }
+
+    /// @brief Retrieve the next batch of neighbors from the index.
+    ///
+    /// This function provides the basic exception guarantee with the following semantics:
+    ///
+    /// * If an exception is thrown during search, the contents and batch number of the
+    ///   ``BatchIterator`` remain unchanged. This can be detected by using ``batch()``
+    ///   to determine the current batch buffered in this container.
+    ///
+    /// * If an exception is thrown after search (this should be extremely rare), then the
+    ///   contents and batch number will be incremented but the contents of container may
+    ///   be less than the schedule's requested batch size.
+    ///
+    ///   This may cause some de-sync between the yielded elements and the batch size
+    ///   requested by the schedule, but the iterator should continue to work.
+    ///
+    /// After this function returns, a new batch of neighbors can be retrieved using this
+    /// container's iterator interface.
+    ///
+    /// If ``done()`` returns ``true`` prior to calling this function, then the internal
+    /// result buffer will be emptied and no new neighbors will be returned.
+    ///
+    /// @sa ``done()``
+    void next() {
+        if (done()) {
+            results_.clear();
+            return;
+        }
+
+        // Increment the number of neighbors to return.
+        // Defer actually incrementing of the member variable until after search is
+        // completed to maintain class invariants in the presence of exceptions.
+        size_t this_iteration = iteration_ + 1;
+        size_t max_candidates = schedule_.max_candidates(this_iteration);
+        const auto& p = schedule_.for_iteration(this_iteration);
+        scratchspace_.apply(p);
+
+        // Conservatively set the `restart_search_` so that if an exception is thrown during
+        // search, we begin from scratch on the next round.
+        //
+        // Make a copy of the old value for capturing in the lambda below.
+        bool restart_search_copy = std::exchange(restart_search_, true);
+
+        // Rerun search using the stashed contents of the search buffer.
+        parent_->experimental_escape_hatch([&]<std::integral I>(
+                                               const auto& graph,
+                                               const auto& data,
+                                               const auto& SVS_UNUSED(distance),
+                                               std::span<const I> entry_points
+                                           ) {
+            auto search_closure =
+                [&](const auto& query, const auto& accessor, auto& d, auto& buffer) {
+                    vamana::greedy_search(
+                        graph,
+                        data,
+                        accessor,
+                        query,
+                        d,
+                        buffer,
+                        RestartInitializer<I>{entry_points, restart_search_copy},
+                        parent_->internal_search_builder(),
+                        vamana::GreedySearchPrefetchParameters{
+                            p.prefetch_lookahead_,
+                            p.prefetch_step_,
+                        }
+                    );
+
+                    // TODO: Need a better way of identifying if we're working with
+                    // the dynamic index or not.
+                    if constexpr (Index::needs_id_translation) {
+                        buffer.cleanup();
+                    }
+                };
+
+            extensions::single_search(
+                data,
+                scratchspace_.buffer,
+                scratchspace_.scratch,
+                lib::as_const_span(query_),
+                search_closure
+            );
+        });
+
+        // Search was successful.
+        // We do not need to start the next search from scratch.
+        ++iteration_;
+        restart_search_ = false;
+        copy_from_scratch(max_candidates);
+    }
+
+  private:
+    // The index we are accessing.
+    const Index* parent_;
+    // Local buffer for the query.
+    std::vector<QueryType> query_;
+    // Scratchspace for search.
+    // TODO: Provide a better API for scratch spaces.
+    scratchspace_type scratchspace_;
+    // Filtered results from search.
+    std::vector<Neighbor<external_id_type>> results_{};
+    // Yielded neighbors.
+    // Keep track of internal IDs since (generally speaking), internal IDs should have
+    // a smaller width than external IDs.
+    std::unordered_set<internal_id_type> yielded_{};
+    // Which iteration is currently being processed.
+    size_t iteration_ = 0;
+    // If an exception is thrown during search,
+    bool restart_search_ = false;
+    // The search buffer schedule.
+    Schedule schedule_;
+};
+
+// Deduction Guides
+template <typename Index, typename QueryType, IteratorSchedule Schedule>
+BatchIterator(const Index*, std::span<const QueryType>, Schedule)
+    -> BatchIterator<Index, QueryType, Schedule>;
+
+} // namespace svs::index::vamana

--- a/include/svs/index/vamana/iterator_schedule.h
+++ b/include/svs/index/vamana/iterator_schedule.h
@@ -1,0 +1,405 @@
+/*
+ * Copyright 2024 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// svs
+#include "svs/index/vamana/search_params.h"
+#include "svs/lib/preprocessor.h"
+
+// stl
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+namespace svs::index::vamana {
+
+// clang-format off
+
+/// @brief Protocol for ``BatchIterator`` compatible growth schedules.
+///
+/// Abstract schedules must take an iteration number and yield the search parameters to
+/// use for that iteration.
+///
+/// Generally speaking, the schedule must (at least) increase the search buffer capacity
+/// in order to ensure new valid items are returned on the next invocation of the iterator.
+///
+/// It is up to the implementation of the schedule to ensure that this holds.
+/// @code{.cpp}
+/// template<typename T>
+/// concept IteratorSchedule = requires(const T& const_schedule, size_t iteration) {
+///    // Return the schedule to use for the next iteration.
+///    // The underlying schedule must be const invocable/pure for exception safety
+///    // reasons.
+///    { const_schedule.for_iteration(iteration) } ->
+///        std::convertible_to<vamana::VamanaSearchParameters>;
+///
+///    // The maximum number of valid elements to yield from the search buffer.
+///    // This is necessary for datasets that use reranking, since those datasets may need
+///    // to super-sample in order to guarantee the quality of the top-K neighbors.
+///    //
+///    // This method takes the iteration number to provide a mechanism though with the
+///    // number of neighbors can be modified.
+///    { const_schedule.max_candidates(iteration) } -> std::same_as<size_t>;
+/// };
+/// @endcode
+template <typename T>
+concept IteratorSchedule =
+std::is_nothrow_swappable_v<T> &&
+requires(const T& const_schedule, size_t iteration) {
+    { const_schedule.for_iteration(iteration) } ->
+        std::convertible_to<vamana::VamanaSearchParameters>;
+    { const_schedule.max_candidates(iteration) } -> std::same_as<size_t>;
+};
+// clang-format on
+
+/////
+///// Concrete Schedules
+/////
+
+/// @brief A simple schedule that accepts a batchsize and base parameters.
+///
+/// On each iteration, the search window size and buffer capacity are both increased by
+/// the batchsize.
+///
+/// All other aspects of the base parameters are preserved (such as prefetch parameters
+/// and visited filter).
+class DefaultSchedule {
+  public:
+    /// @brief Construct a new default schedule.
+    DefaultSchedule(const vamana::VamanaSearchParameters& base, size_t batch_size)
+        : base_parameters_{base}
+        , batch_size_{batch_size} {}
+
+    /// @brief Return parameters for batch ``i``.
+    ///
+    /// Increments the search window size and capacity of the base search parameters by
+    /// @code{.cpp}
+    /// i * batch_size
+    /// @endcode
+    /// where ``batch_size`` is the value passed to the class constructor.
+    vamana::VamanaSearchParameters for_iteration(size_t i) const {
+        // Copy the base parameters, then scale the search window size and capacity by
+        // `batch_size_` on each iteration.
+        auto p = base_parameters_;
+        p.buffer_config_.increment(i * batch_size_);
+        return p;
+    }
+
+    /// @brief Return maximum number of candidates to return for iteration ``i``.
+    ///
+    /// The return value is constant and equal to the ``batch_size`` argument provided to
+    /// the class constructor.
+    size_t max_candidates(size_t SVS_UNUSED(i)) const { return batch_size_; }
+
+    ///// Members
+  private:
+    // The starting search parameters to use for the first iteration of search.
+    vamana::VamanaSearchParameters base_parameters_;
+    // The new number of elements to return on each iteration.
+    size_t batch_size_;
+};
+
+static_assert(
+    IteratorSchedule<DefaultSchedule>,
+    "Default Schedule must satisfy the IteratorSchedule concept."
+);
+
+/// An iterator schedule with separate scaling parameters for the Vamana buffer
+/// configuration and batchsize.
+class LinearSchedule {
+  private:
+    ///// Members
+    vamana::VamanaSearchParameters base_parameters_;
+    uint16_t scale_search_window_;
+    uint16_t scale_buffer_capacity_;
+    int16_t enable_filter_after_;
+    uint16_t batch_size_start_;
+    uint16_t scale_batch_size_;
+
+    // Invariant Checks.
+    void check_invariants() {
+        // If the capacity scaling is slower than the window scaling, they will eventually
+        // collide.
+        if (scale_buffer_capacity_ < scale_search_window_) {
+            throw ANNEXCEPTION("Capacity scaling must be at least as big as window scaling!"
+            );
+        }
+        // Clamp filter enablement.
+        enable_filter_after_ = std::max(enable_filter_after_, int16_t{-1});
+        // Batch size should be at least one.
+        // Otherwise, why are we creating an iterator?
+        if (batch_size_start_ == 0) {
+            throw ANNEXCEPTION(
+                "Batch size start must be at least 1. Instead, got {}.", batch_size_start_
+            );
+        }
+    }
+
+  public:
+    LinearSchedule(
+        const vamana::VamanaSearchParameters& base_parameters,
+        uint16_t scale_search_window,
+        uint16_t scale_buffer_capacity,
+        int16_t enable_filter_after,
+        uint16_t batch_size_start,
+        uint16_t scale_batch_size
+    )
+        : base_parameters_{base_parameters}
+        , scale_search_window_{scale_search_window}
+        , scale_buffer_capacity_{scale_buffer_capacity}
+        , enable_filter_after_{enable_filter_after}
+        , batch_size_start_{batch_size_start}
+        , scale_batch_size_{scale_batch_size} {
+        // Check invariants.
+        check_invariants();
+    }
+
+    LinearSchedule(
+        const vamana::VamanaSearchParameters& base_parameters,
+        size_t batchsize,
+        int16_t enable_filter_after = -1
+    )
+        : LinearSchedule{
+              base_parameters,
+              lib::narrow<uint16_t>(batchsize),
+              lib::narrow_cast<uint16_t>(batchsize),
+              enable_filter_after,
+              lib::narrow_cast<uint16_t>(batchsize),
+              uint16_t{0}} {}
+
+    /// @brief Update the search buffer scaling parameters.
+    ///
+    /// @param config Config to apply for the scaling parameters.
+    ///
+    /// This method accepts a ``vamana::SearchBufferConfig`` because the invariant that
+    /// the scaling for buffer capacity must be at least as large as the scaling for the
+    /// search window size.
+    ///
+    /// This invariant is automatically guarenteed by the ``vamana::SearchBufferConfig``.
+    ///
+    /// @code{cpp}
+    /// auto schedule = svs::index::vamana::LinearSchedule{...};
+    /// // Increase the search window size by 10 and the buffer capacity by 20 on each
+    /// // iteration.
+    /// schedule.buffer_scaling({10, 20});
+    /// @endcode
+    LinearSchedule& buffer_scaling(vamana::SearchBufferConfig config) {
+        scale_search_window_ = config.get_search_window_size();
+        scale_buffer_capacity_ = config.get_total_capacity();
+        return *this;
+    }
+
+    /// @brief Enable the visited filter on and after the specified iteration.
+    ///
+    /// If the visited filter is not needed, providing a negative value or using
+    /// ``disable_filter()`` is sufficient.
+    LinearSchedule& enable_filter_after(int16_t iteration) {
+        enable_filter_after_ = std::max(iteration, int16_t{-1});
+        return *this;
+    }
+
+    /// @brief Disable the visited filter from ever being used.
+    LinearSchedule& disable_filter() { return enable_filter_after(-1); }
+
+    /// @brief Configure the starting batch size.
+    ///
+    /// The starting batch size must be at least 1.
+    ///
+    /// @throws ANNException if the batchsize is no at least 1.
+    LinearSchedule& starting_batch_size(uint16_t batch_size) {
+        if (batch_size == 0) {
+            throw ANNEXCEPTION("Starting batch size must be nonzero.");
+        }
+        batch_size_start_ = batch_size;
+        return *this;
+    }
+
+    /// @brief Configure the batch size scaling.
+    ///
+    /// Batch size scaling provides a way of progressively yielding more neighbors on each
+    /// iteration using the formula:
+    /// @code{cpp}
+    /// batch_size + scaling * iterations;
+    /// @endcode
+    /// To yield the same number of neighbors on each iteration, set the scaling to 0;
+    ///
+    /// Note that the number of yielded neighbors is not guarenteed to be the requested
+    /// batchsize depending on the scaling of the buffer configuration.
+    LinearSchedule& batch_size_scaling(uint16_t scaling) {
+        scale_batch_size_ = scaling;
+        return *this;
+    }
+
+    /// @brief Disable batch size scaling.
+    ///
+    /// This means the batch iterator will attempt to return the same number of neighbors
+    /// on each iteration.
+    ///
+    /// Note that the number of yielded neighbors is not guarenteed to be the requested
+    /// batchsize depending on the scaling of the buffer configuration.
+    LinearSchedule& disable_batch_size_scaling() { return batch_size_scaling(0); }
+
+    /// @brief Return search parameters for iteration ``i``.
+    ///
+    /// @param i The iteration number.
+    ///
+    /// The yielded ``vamana::VamanaSearchParameters`` will have its search window size
+    /// and capacity scaled from their baseline.
+    ///
+    /// The visited filter will also be enabled on and after its specified iteration,
+    /// if applicable.
+    vamana::VamanaSearchParameters for_iteration(size_t i) const {
+        // Copy the base parameters and scale the fields according to the internal
+        // configuration.
+        auto p = base_parameters_;
+        p.buffer_config_.increment({scale_search_window_ * i, scale_buffer_capacity_ * i});
+
+        // `narrow_cast` guarenteed to succeed since we've already ruled out negative
+        // values for `enable_filter_after_`.
+        if (enable_filter_after_ > -1 &&
+            i >= lib::narrow_cast<size_t>(enable_filter_after_)) {
+            p.search_buffer_visited_set_ = true;
+        }
+        return p;
+    }
+
+    /// @brief Return the maximum number of candidates to yield this iteration.
+    ///
+    /// @param i The iteration number.
+    ///
+    /// Linearly scales the starting batchsize with by scaling parameter.
+    size_t max_candidates(size_t i) const {
+        return batch_size_start_ + scale_batch_size_ * i;
+    }
+};
+
+static_assert(
+    IteratorSchedule<LinearSchedule>,
+    "LinearSchedule must satisfy the IteratorSchedule concept."
+);
+
+/////
+///// Type Erasure
+/////
+
+// A type-erased implementation of an IteratorSchedule.
+class AbstractIteratorSchedule {
+  private:
+    struct Interface {
+        virtual vamana::VamanaSearchParameters for_iteration(size_t iteration) const = 0;
+        virtual size_t max_candidates(size_t iteration) const = 0;
+        virtual std::unique_ptr<Interface> clone() const = 0;
+
+        virtual ~Interface() = default;
+    };
+
+    template <vamana::IteratorSchedule Impl> struct Implementation : public Interface {
+        ///// Constructors
+        Implementation(Impl&& impl)
+            : impl_{std::move(impl)} {}
+        Implementation(const Impl& impl)
+            : impl_{impl} {}
+        template <typename... Args>
+        Implementation(std::in_place_t SVS_UNUSED(tag), Args&&... args)
+            : impl_{SVS_FWD(args)...} {}
+
+        ///// Interface implementation
+        virtual vamana::VamanaSearchParameters for_iteration(size_t iteration
+        ) const override {
+            return impl_.for_iteration(iteration);
+        }
+
+        virtual size_t max_candidates(size_t iteration) const override {
+            return impl_.max_candidates(iteration);
+        }
+
+        virtual std::unique_ptr<Interface> clone() const override {
+            // Clone by copy-construction.
+            return std::make_unique<Implementation>(impl_);
+        }
+
+        // The concrete implementation.
+        Impl impl_;
+    };
+
+    ///// Members
+    std::unique_ptr<Interface> iface_;
+
+  public:
+    // Don't allow uninitialized schedules.
+    // We have `std::optional` for that.
+    AbstractIteratorSchedule() = delete;
+
+    /// @brief Construct a new abstract schedule around the concrete implementation.
+    template <
+        IteratorSchedule Schedule,
+        typename = std::enable_if_t<
+            !std::is_same_v<std::remove_cvref_t<Schedule>, AbstractIteratorSchedule>>>
+    explicit AbstractIteratorSchedule(Schedule schedule)
+        : iface_{std::make_unique<Implementation<Schedule>>(std::move(schedule))} {}
+
+    /// @brief Construct a new abstract schedule.
+    ///
+    /// The requested implementation will be constructed in-place by forwarding the
+    /// arguments to the class's constructor.
+    template <IteratorSchedule Schedule, typename... Args>
+    AbstractIteratorSchedule(std::in_place_type_t<Schedule> SVS_UNUSED(tag), Args&&... args)
+        : iface_{std::make_unique<Implementation<Schedule>>(
+              std::in_place, SVS_FWD(args)...
+          )} {}
+
+    /// @brief Replace the wrapped schedule with a new schedule.
+    template <IteratorSchedule Schedule> void reset(Schedule schedule) {
+        iface_ = std::make_unique<Implementation<Schedule>>(std::move(schedule));
+    }
+
+    /// @brief Return the search parameters from the wrapped schedule.
+    vamana::VamanaSearchParameters for_iteration(size_t iteration) const {
+        return iface_->for_iteration(iteration);
+    }
+
+    /// @brief Return the maximum candidates from the wrapped schedule.
+    size_t max_candidates(size_t iteration) const {
+        return iface_->max_candidates(iteration);
+    }
+
+    // Special member functions.
+    // By default, `std::unique_ptr` is not cloneable.
+    // However, we've explicitly provided a `.clone()` method, so we can define copy
+    // constructors and assignment operators.
+    AbstractIteratorSchedule(const AbstractIteratorSchedule& other) noexcept
+        : iface_{other.iface_->clone()} {}
+
+    AbstractIteratorSchedule& operator=(const AbstractIteratorSchedule& other) {
+        if (this != &other) {
+            iface_ = other.iface_->clone();
+        }
+        return *this;
+    }
+
+    // Default the move operations and the destructor.
+    AbstractIteratorSchedule(AbstractIteratorSchedule&& other) = default;
+    AbstractIteratorSchedule& operator=(AbstractIteratorSchedule&& other) = default;
+    ~AbstractIteratorSchedule() = default;
+};
+
+static_assert(
+    IteratorSchedule<AbstractIteratorSchedule>,
+    "AbstractIteratorSchedule must satisfy the IteratorSchedule concept."
+);
+
+} // namespace svs::index::vamana

--- a/include/svs/index/vamana/vamana_build.h
+++ b/include/svs/index/vamana/vamana_build.h
@@ -346,7 +346,7 @@ class VamanaBuilder {
                         graph_search_query,
                         graph_search_distance,
                         search_buffer,
-                        entry_points,
+                        vamana::EntryPointInitializer{lib::as_const_span(entry_points)},
                         NeighborBuilder(),
                         tracker,
                         prefetch_hint_

--- a/include/svs/lib/invoke.h
+++ b/include/svs/lib/invoke.h
@@ -28,7 +28,7 @@ struct dispatcher {
         requires requires(Tag&& tag, Args&&... args) {
                      svs_invoke(SVS_FWD(tag), SVS_FWD(args)...);
                  }
-    SVS_FORCE_INLINE auto operator()(Tag&& tag, Args&&... args) const
+    SVS_FORCE_INLINE constexpr auto operator()(Tag&& tag, Args&&... args) const
         noexcept(noexcept(svs_invoke(SVS_FWD(tag), SVS_FWD(args)...)))
             -> decltype(svs_invoke(SVS_FWD(tag), SVS_FWD(args)...)) {
         return svs_invoke(SVS_FWD(tag), SVS_FWD(args)...);

--- a/include/svs/lib/neighbor.h
+++ b/include/svs/lib/neighbor.h
@@ -198,6 +198,7 @@ struct Visited {
         : visited_{visited} {}
     constexpr bool visited() const { return visited_; }
     constexpr void set_visited() { visited_ = true; }
+    constexpr void clear_visited() { visited_ = false; }
 
     // members
     bool visited_;
@@ -232,6 +233,7 @@ class ValidVisit {
         : value_{valid ? valid_mask : uint8_t{0x0}} {}
 
     constexpr void set_visited() { value_ |= visited_mask; }
+    constexpr void clear_visited() { value_ &= ~visited_mask; }
     constexpr bool visited() const { return (value_ & visited_mask) != 0; }
     constexpr bool valid() const { return (value_ & valid_mask) != 0; }
 

--- a/include/svs/lib/preprocessor.h
+++ b/include/svs/lib/preprocessor.h
@@ -102,6 +102,9 @@ consteval bool is_one_or_zero(const char* ptr) {
         return std::move(*this);                     \
     }
 
+// Temporary measure to disable the BatchIterator for not supported types.
+#define SVS_TEMPORARY_DISABLE_SINGLE_SEARCH
+
 /////
 ///// Intel(R) AVX extensions
 /////

--- a/include/svs/lib/scopeguard.h
+++ b/include/svs/lib/scopeguard.h
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2023 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// svs
+#include "svs/lib/preprocessor.h"
+
+// stl
+#include <cassert>
+#include <type_traits>
+
+namespace svs::lib {
+
+/////
+///// ScopeGuard
+/////
+
+namespace detail {
+
+// A dummy type used for non-cancelable scope guards providing a similar interface to a
+// boolean.
+//
+// This type should be empty to avoid increasing the memory footprint of non-cancelable
+// guards.
+struct AlwaysFalse {
+    constexpr AlwaysFalse() = default;
+    constexpr AlwaysFalse([[maybe_unused]] bool init) {
+        // `AlwaysFalse` should never be initialized to `true`.
+        assert(init == false);
+    }
+
+    constexpr AlwaysFalse& operator=([[maybe_unused]] bool value) {
+        // `AlwaysFalse` should never be assigned to `true`.
+        assert(value == false);
+        return *this;
+    }
+    constexpr operator bool() { return false; }
+};
+
+} // namespace detail
+
+///
+/// @brief Scope guard that invokes its callback's call operator upon destruction.
+///
+/// This is a class that provides a RAII style callback/cleanup mechanism at the end of
+/// a scoped block.
+///
+/// When this object's desctructor is run, it will invoke
+/// ```c++
+/// std::remove_reference_t<T>::operator()()
+/// ```
+/// of its contained callback.
+///
+/// Expects the callback operator to be ``noexcept`` and have a ``void`` return type.
+///
+/// This class is non-copyable and non-moveable.
+///
+/// The utility function ``svs::lib::make_scope_guard`` and
+/// ``svs::lib::make_dismissable_scope_guard`` can be used for type deduction when
+/// creating a ScopeGuard. In the latter case, the created ``ScopeGuard`` can be dismissed
+/// using the ``.dismiss()`` method. Dismissed ``ScopeGuard``s will not run the deferred
+/// callable.
+///
+/// ```c++
+/// size_t count = 0;
+/// {
+///     auto guard = svs::lib::make_scope_guard([&count]() noexcept {
+///         ++count;
+///     });
+/// }
+/// assert(count == 1);
+///
+/// {
+///     auto guard = svs::lib::make_dismissable_scope_guard([&count]() noexcept {
+///         ++count;
+///     });
+/// }
+/// assert(count == 2);
+///
+/// {
+///     auto guard = svs::lib::make_dismissable_scope_guard([&count]() noexcept {
+///         ++count;
+///     });
+///     guard.dismiss();
+/// }
+/// // Captured function was never run.
+/// assert(count == 2);
+/// ```
+///
+/// @tparam T The type of the callback operator. May be a reference type if the ScopeGuard
+///     was constructed from an l-value refences to the provided callback.
+/// @tparam Dismissable Boolean value parameter indicating whether or not this ScopeGuard
+///     is dismissable.
+///
+/// @sa ``svs::lib::make_scope_guard``, ``svs::lib::make_dismissable_scope_guard``.
+///
+template <typename T, bool Dismissable> class ScopeGuard {
+  public:
+    /// Definition: T
+    using callback_type = T;
+    static constexpr bool is_reference = std::is_reference_v<std::remove_const_t<T>>;
+    using dismissed_type = std::conditional_t<Dismissable, bool, detail::AlwaysFalse>;
+
+    static_assert(
+        std::is_nothrow_invocable_v<callback_type>, "ScopeGuard callable must be noexcept."
+    );
+
+    static_assert(std::is_void_v<std::invoke_result_t<callback_type>>);
+
+    /// ScopeGuard is not default constructible.
+    ScopeGuard() = delete;
+
+    ///
+    /// @brief Create a ScopeGuard for the given callback.
+    ///
+    /// Implementation notes:
+    ///
+    /// If the callback is a reference type, then C++ reference collapsing yields
+    /// ```
+    /// callback_type&& -> T& && -> T&
+    /// ```
+    /// which turns the argument `f` to a reference.
+    ///
+    /// If the callback is a non-reference type, then we have an r-value reference as
+    /// expected.
+    ///
+    explicit ScopeGuard(callback_type&& f)
+        : f_{SVS_FWD(f)} {}
+
+    /// @brief Dismiss the ScopeGuard so the callable is not invoked.
+    ///
+    /// Requires the ScopeGuard to be dismissable.
+    void dismiss() noexcept
+        requires Dismissable
+    {
+        dismissed_ = true;
+    }
+
+    // Disable the special member functions.
+    ScopeGuard(const ScopeGuard&) = delete;
+    ScopeGuard& operator=(const ScopeGuard&) = delete;
+    ScopeGuard(ScopeGuard&&) = delete;
+    ScopeGuard& operator=(ScopeGuard&&) = delete;
+
+    // Invoke the callback on destruction.
+    ~ScopeGuard() {
+        if (!dismissed_) {
+            f_();
+        }
+    }
+
+    ///// Members
+  private:
+    T f_;
+    [[no_unique_address]] dismissed_type dismissed_{false};
+};
+
+namespace detail {
+template <typename T>
+using deduce_scopeguard_parameter_t =
+    std::conditional_t<std::is_rvalue_reference_v<T>, std::decay_t<T>, T>;
+}
+
+///
+/// @brief Construct an ScopeGuard wrapped around the argument ``f``.
+///
+/// Constructs ScopeGuard around the argument without invoking the object's copy
+/// constructor.
+///
+/// * If ``f`` is given as an l-value reference, the constructed ScopeGuard will reference
+///   ``f``.
+/// * If `f` is given as an r-value reference, then the constructed ScopeGuard will take
+///   ownership of `f` via `f`'s move constructor.
+///
+/// This latter requires ``f`` to be noexcept move constructible.
+///
+template <typename F>
+ScopeGuard<detail::deduce_scopeguard_parameter_t<F&&>, false> make_scope_guard(F&& f) {
+    return ScopeGuard<detail::deduce_scopeguard_parameter_t<F&&>, false>(SVS_FWD(f));
+}
+
+///
+/// @brief Construct an active but dismissable ScopeGuard wrapped around the argument ``f``.
+///
+/// Constructs ScopeGuard around the argument without invoking the object's copy
+/// constructor.
+///
+/// * If ``f`` is given as an l-value reference, the constructed ScopeGuard will reference
+///   ``f``.
+/// * If `f` is given as an r-value reference, then the constructed ScopeGuard will take
+///   ownership of `f` via `f`'s move constructor.
+///
+/// This latter requires ``f`` to be noexcept move constructible.
+///
+template <typename F>
+ScopeGuard<detail::deduce_scopeguard_parameter_t<F&&>, true>
+make_dismissable_scope_guard(F&& f) {
+    return ScopeGuard<detail::deduce_scopeguard_parameter_t<F&&>, true>(SVS_FWD(f));
+}
+
+} // namespace svs::lib

--- a/include/svs/orchestrators/vamana_iterator.h
+++ b/include/svs/orchestrators/vamana_iterator.h
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2024 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// svs-vamana
+#include "svs/index/vamana/iterator.h"
+#include "svs/index/vamana/iterator_schedule.h"
+
+// stl
+#include <memory>
+
+namespace svs {
+
+/// @brief Type-erased wrapper for the low-level Vamana iterator.
+class VamanaIterator {
+  private:
+    struct Interface {
+        virtual svs::index::vamana::VamanaSearchParameters
+        parameters_for_current_batch() const = 0;
+        virtual svs::DataType query_type() const = 0;
+        virtual size_t batch() const = 0;
+        virtual size_t size() const = 0;
+        virtual std::span<const svs::Neighbor<size_t>> results() const = 0;
+        virtual void restart_next_search() = 0;
+        virtual void next() = 0;
+        virtual bool done() const = 0;
+        virtual void update(svs::AnonymousArray<1>) = 0;
+        virtual void
+        update(svs::AnonymousArray<1>, const svs::index::vamana::AbstractIteratorSchedule&) = 0;
+
+        virtual ~Interface() = default;
+    };
+
+    template <typename Index, typename QueryType> struct Implementation : Interface {
+        // For the type-erased implementation - require the schedule to be type-erased as
+        // well.
+        using type = svs::index::vamana::
+            BatchIterator<Index, QueryType, svs::index::vamana::AbstractIteratorSchedule>;
+
+        Implementation(
+            const Index& index,
+            std::span<const QueryType> query,
+            svs::index::vamana::AbstractIteratorSchedule schedule
+        )
+            : impl_{index, query, std::move(schedule)} {}
+
+        svs::index::vamana::VamanaSearchParameters
+        parameters_for_current_batch() const override {
+            return impl_.parameters_for_current_iteration();
+        }
+
+        svs::DataType query_type() const override { return svs::datatype_v<QueryType>; }
+
+        size_t batch() const override { return impl_.batch(); }
+        size_t size() const override { return impl_.size(); }
+
+        std::span<const svs::Neighbor<size_t>> results() const override {
+            return impl_.contents();
+        }
+
+        void restart_next_search() override { impl_.restart_next_search(); }
+        void next() override { impl_.next(); }
+        bool done() const override { return impl_.done(); }
+
+        // Query Updates
+        void update(svs::AnonymousArray<1> newquery) override {
+            if (newquery.type() == svs::datatype_v<QueryType>) {
+                impl_.update(
+                    std::span<const QueryType>(get<QueryType>(newquery), newquery.size(0))
+                );
+            }
+        }
+
+        void update(
+            svs::AnonymousArray<1> newquery,
+            const svs::index::vamana::AbstractIteratorSchedule& newschedule
+        ) override {
+            if (newquery.type() == svs::datatype_v<QueryType>) {
+                impl_.update(
+                    std::span<const QueryType>(get<QueryType>(newquery), newquery.size(0)),
+                    newschedule
+                );
+            }
+        }
+
+        // Member
+        type impl_;
+    };
+
+    std::unique_ptr<Interface> impl_;
+
+  public:
+    /// @brief Construct a new batch iterator for the query over the index.
+    ///
+    /// The results for the first batch will be available once the constructor completes.
+    ///
+    /// Argument ``schedule`` will be used to adjust the search parameters for each batch.
+    /// An internal copy of the query will be made.
+    template <typename Index, typename QueryType>
+    VamanaIterator(
+        const Index& parent,
+        std::span<const QueryType> query,
+        svs::index::vamana::AbstractIteratorSchedule schedule
+    )
+        : impl_{std::make_unique<Implementation<Index, QueryType>>(
+              parent, query, std::move(schedule)
+          )} {}
+
+    /// @brief Return the search parameters used for the current batch.
+    [[nodiscard]] svs::index::vamana::VamanaSearchParameters
+    parameters_for_current_batch() const {
+        return impl_->parameters_for_current_batch();
+    }
+
+    /// @brief Return the element type of the captured query.
+    [[nodiscard]] svs::DataType query_type() const { return impl_->query_type(); }
+
+    /// @brief Return the current batch number.
+    [[nodiscard]] size_t batch() const { return impl_->batch(); }
+
+    /// @brief Return the number of results for the current batch.
+    [[nodiscard]] size_t size() const { return impl_->size(); }
+
+    /// @brief Return a span of the results for the current batch.
+    [[nodiscard]] std::span<const svs::Neighbor<size_t>> results() const {
+        return impl_->results();
+    }
+
+    /// @brief Retrieve a new batch of results.
+    ///
+    /// After calling this method, previous results will no longer be available.
+    /// This method invalidates previous values return by ``results()``.
+    void next() { impl_->next(); }
+
+    /// @brief Signal that the next batch search should begin entirely from scratch.
+    ///
+    /// The iterator records some internal state to accelerate future calls to ``next()``.
+    /// This caching of results may yield slightly different results than beginning index
+    /// search completely over from the original entry points.
+    ///
+    /// Calling this method signals the iterator to abandon its cached state.
+    ///
+    /// This can be helpful for measuring performance and verifying recall values.
+    void restart_next_search() const { impl_->restart_next_search(); }
+
+    /// @brief Return whether or not all entries in the index have been yielded.
+    ///
+    /// This transition is triggered by an invocation of ``next()``.
+    /// After ``done() == true``, future calls to ``next()`` will yield an empty set of
+    /// candidates and will not change the results of ``batch()`` or
+    /// ``parameters_for_current_batch()``.
+    bool done() const { return impl_->done(); }
+
+    /// @brief Update the query contained in the iterator and begin a new search.
+    ///
+    ///
+    /// Thus function provides the following exception guarentee:
+    ///
+    /// * If the new search fails, the state of the iterator is valid for the old query.
+    /// * If an exception is thrown after search, the contents of the iterator are valid
+    ///   for the new query.
+    ///
+    /// Throws an ``svs::ANNException`` if the provided query type does not match
+    /// ``query_type()``.
+    template <typename QueryType> void update(std::span<const QueryType> newquery) {
+        impl_->update(svs::AnonymousArray<1>{newquery.data(), newquery.size()}, newquery);
+    }
+
+    /// @brief Update the query contained in the iterator and begin a new search.
+    ///
+    /// Thus function provides the following exception guarentee:
+    ///
+    /// * If the new search fails, the state of the iterator is valid for the old query.
+    /// * If an exception is thrown after search, the contents of the iterator are valid
+    ///   for the new query.
+    /// * The copy constructor for ``newschedule`` may be invoked. If it is and it throws
+    ///   an exception, the state of the iterator is valid for the old query.
+    ///
+    /// Throws an ``svs::ANNException`` if the provided query type does not match
+    /// ``query_type()``.
+    template <typename QueryType, svs::index::vamana::IteratorSchedule Schedule>
+    void update(std::span<const QueryType> newquery, const Schedule& newschedule) {
+        impl_->update(
+            svs::AnonymousArray<1>{newquery.data(), newquery.size()},
+            svs::index::vamana::AbstractIteratorSchedule(newschedule)
+        );
+    }
+};
+
+} // namespace svs

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,6 +77,7 @@ set(TEST_SOURCES
     ${TEST_DIR}/svs/lib/readwrite.cpp
     ${TEST_DIR}/svs/lib/saveload.cpp
     ${TEST_DIR}/svs/lib/saveload/load.cpp
+    ${TEST_DIR}/svs/lib/scopeguard.cpp
     ${TEST_DIR}/svs/lib/spinlock.cpp
     ${TEST_DIR}/svs/lib/static.cpp
     ${TEST_DIR}/svs/lib/timing.cpp
@@ -132,7 +133,9 @@ set(TEST_SOURCES
     ${TEST_DIR}/svs/index/vamana/search_buffer.cpp
     ${TEST_DIR}/svs/index/vamana/search_parameters.cpp
     ${TEST_DIR}/svs/index/vamana/vamana_build.cpp
-    ${TEST_DIR}/svs/index/vamana/vamana_build.cpp
+    ${TEST_DIR}/svs/index/vamana/iterator_schedule.cpp
+    ${TEST_DIR}/svs/index/vamana/iterator_example.cpp
+    ${TEST_DIR}/svs/index/vamana/iterator.cpp
     # Inverted
     ${TEST_DIR}/svs/index/inverted/clustering.cpp
 

--- a/tests/svs/index/vamana/iterator.cpp
+++ b/tests/svs/index/vamana/iterator.cpp
@@ -1,0 +1,329 @@
+/*
+ * Copyright 2024 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// header under test
+#include "svs/index/vamana/iterator.h"
+
+// svstest
+#include "tests/utils/test_dataset.h"
+#include "tests/utils/vamana_reference.h"
+
+// catch2
+#include "catch2/catch_test_macros.hpp"
+
+// stl
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace {
+
+// A static countdown to throwing an exception.
+// This enables testing the restart functionality of the iterator.
+size_t EXCEPTION_COUNTDOWN = 0;
+
+// A wrapper around the L2 distance that throws when the countdown reaches zero.
+struct ThrowingL2 {
+    using compare = std::less<>;
+    static float compute(std::span<const float> left, std::span<const float> right) {
+        // If the exception countdown is active (non-zero), decrement the countdown.
+        // If this action caused the countdown to hit zero, throw an exception.
+        if (EXCEPTION_COUNTDOWN != 0) {
+            --EXCEPTION_COUNTDOWN;
+            if (EXCEPTION_COUNTDOWN == 0) {
+                throw ANNEXCEPTION("Exception countdown triggered!");
+            }
+        }
+        auto real = svs::DistanceL2{};
+        return svs::distance::compute(real, left, right);
+    }
+};
+
+} // namespace
+
+template <> struct svs::index::vamana::PruneStrategy<ThrowingL2> {
+    using type = ProgressivePruneStrategy;
+};
+
+namespace {
+
+const size_t QUERIES_TO_CHECK = 10;
+
+// Common test routines for the static and dynamic indexes.
+template <typename Index, typename IDChecker = svs::lib::Returns<svs::lib::Const<true>>>
+void check(
+    Index& index,
+    svs::data::ConstSimpleDataView<float> queries,
+    svs::data::ConstSimpleDataView<uint32_t> groundtruth,
+    IDChecker& checker
+) {
+    const size_t num_neighbors = 100;
+    // Through an exception during search every `throw_exception_every` batches.
+    const size_t throw_exception_every = 3;
+    const auto batchsizes = std::vector<size_t>{{10, 20, 25, 50, 100}};
+
+    CATCH_REQUIRE(index.size() > num_neighbors);
+    auto p = svs::index::vamana::VamanaSearchParameters{
+        {num_neighbors, num_neighbors}, false, 0, 0};
+
+    auto scratch = index.scratchspace(p);
+
+    auto id_to_distance = std::unordered_map<size_t, float>();
+    auto id_buffer = std::vector<size_t>();
+
+    CATCH_REQUIRE(checker(id_to_distance));
+
+    auto from_iterator = std::unordered_set<size_t>();
+    for (size_t query_index = 0; query_index < QUERIES_TO_CHECK; ++query_index) {
+        auto query = queries.get_datum(query_index);
+
+        // Perform a single, full-precision search to obtain reference results.
+        index.search(query, scratch);
+        const auto& buffer = scratch.buffer;
+
+        id_to_distance.clear();
+        id_buffer.clear();
+        for (const auto& neighbor : buffer) {
+            size_t id = [&]() -> size_t {
+                if constexpr (Index::needs_id_translation) {
+                    return index.translate_internal_id(neighbor.id());
+                } else {
+                    return neighbor.id();
+                }
+            }();
+            id_to_distance.insert({id, neighbor.distance()});
+            id_buffer.push_back(id);
+        }
+
+        // Ensure we have reasonable recall between.
+        CATCH_REQUIRE(
+            svs::lib::count_intersect(id_buffer, groundtruth.get_datum(query_index)) >=
+            0.95 * num_neighbors
+        );
+
+        // Begin performing batch searches.
+        for (auto batchsize : batchsizes) {
+            CATCH_REQUIRE(num_neighbors % batchsize == 0);
+            size_t num_batches = num_neighbors / batchsize;
+
+            // Initialize the base search parameters with more than the configured batch
+            // size. This will check that the internal limiting mechanisms only return
+            // at most `batchsize` elements.
+            auto sp = svs::index::vamana::VamanaSearchParameters{
+                {batchsize + 10, batchsize + 10}, false, 0, 0};
+
+            auto iterator = svs::index::vamana::BatchIterator{
+                index, query, svs::index::vamana::DefaultSchedule{sp, batchsize}};
+
+            // TODO: how do we communicate if something goes wrong on the on the iterator
+            // end and we cannot return `batch_size()` neighbors?
+            CATCH_REQUIRE(iterator.size() == batchsize);
+
+            from_iterator.clear();
+            size_t similar_count = 0;
+
+            // IDs returned from the most recent batch.
+            // Keep track of this because we want to ensure that if an exception is thrown
+            // during search, the state of the iterator is unchanged.
+            auto ids_returned_this_batch = std::vector<size_t>();
+            for (size_t batch = 0; batch < num_batches; ++batch) {
+                // Make sure the batch number is the same.
+                CATCH_REQUIRE(iterator.batch() == batch);
+                ids_returned_this_batch.clear();
+                for (auto i : iterator) {
+                    auto id = i.id();
+                    // Make sure that this ID has not been returned yet.
+                    CATCH_REQUIRE(!from_iterator.contains(id));
+                    auto itr = id_to_distance.find(id);
+                    if (itr != id_to_distance.end()) {
+                        // Make sure the returned distances match.
+                        CATCH_REQUIRE(itr->second == i.distance());
+                        ++similar_count;
+                    }
+
+                    // Insert the ID into the `from_iterator` container to detect for
+                    // duplicates from future calls.
+                    from_iterator.insert(id);
+                    ids_returned_this_batch.push_back(id);
+                }
+
+                // The number of IDs returned should equal the number of IDs reported
+                // by the iterator.
+                CATCH_REQUIRE(ids_returned_this_batch.size() == iterator.size());
+                CATCH_REQUIRE(ids_returned_this_batch.size() == batchsize);
+
+                // Now we've extracted the neighbors, decide if we are going to try again
+                // but throw an exception.
+                //
+                // If so, we want to ensure that the buffer is left in a sane state.
+                // Furthermore, on the next iteration, we want to make sure we can resume
+                // search without incident.
+                if (batch % throw_exception_every == 0) {
+                    EXCEPTION_COUNTDOWN = 50;
+                    CATCH_REQUIRE_THROWS_AS(iterator.next(), svs::ANNException);
+                    // The batch reported by the iterator must be unchanged.
+                    CATCH_REQUIRE(iterator.batch() == batch);
+                    // The contents of the iterator should be unchanged.
+                    CATCH_REQUIRE(iterator.size() == ids_returned_this_batch.size());
+                    CATCH_REQUIRE(std::equal(
+                        iterator.begin(),
+                        iterator.end(),
+                        ids_returned_this_batch.begin(),
+                        [](svs::NeighborLike auto left, size_t right) {
+                            return left.id() == right;
+                        }
+                    ));
+                }
+
+                iterator.next();
+            }
+
+            // Make sure the expected number of neighbors has been obtained.
+            CATCH_REQUIRE(from_iterator.size() == num_neighbors);
+
+            // Ensure that the results returned by the iterator are "substantively similar"
+            // to those returned from the full search.
+            CATCH_REQUIRE(similar_count >= 0.98 * num_neighbors);
+        }
+
+        // Invoke the checker on the IDs returned from the iterator.
+        CATCH_REQUIRE(checker(from_iterator));
+    }
+}
+
+template <typename Index>
+void check(
+    Index& index,
+    svs::data::ConstSimpleDataView<float> queries,
+    svs::data::ConstSimpleDataView<uint32_t> groundtruth
+) {
+    auto checker = svs::lib::Returns<svs::lib::Const<true>>();
+    check(index, queries, groundtruth, checker);
+}
+
+struct DynamicChecker {
+    DynamicChecker(const std::unordered_set<size_t>& valid_ids)
+        : valid_ids_{valid_ids} {}
+
+    // Check whether `id` is valid or not.
+    bool check(size_t id) {
+        seen_.insert(id);
+        return valid_ids_.contains(id);
+    }
+
+    template <std::integral I> bool operator()(const std::unordered_map<I, float>& ids) {
+        for (const auto& itr : ids) {
+            if (!check(itr.first)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    template <std::integral I> bool operator()(const std::unordered_set<I>& ids) {
+        for (auto itr : ids) {
+            if (!check(itr)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void clear() { seen_.clear(); }
+
+    // Valid IDs
+    const std::unordered_set<size_t>& valid_ids_;
+    std::unordered_set<size_t> seen_;
+};
+
+} // namespace
+
+CATCH_TEST_CASE("Vamana Iterator", "[index][vamana][iterator]") {
+    // This tests the general behavior of the iterator for correctness.
+    // It is not concerned with whether the returned neighbors are acurate.
+    //
+    // That reponsibility is delegated to the integration tests.
+    auto queries = test_dataset::queries();
+    auto gt = test_dataset::groundtruth_euclidean();
+    CATCH_SECTION("Static Index") {
+        auto index = test_dataset::vamana::load_test_index(ThrowingL2());
+        check(index, queries.cview(), gt.cview());
+    }
+
+    // For the dynamic index, iterated search should honor the internal deleted state of
+    // IDs.
+    CATCH_SECTION("Dynamic Index") {
+        auto index = test_dataset::vamana::load_dynamic_test_index(ThrowingL2());
+        auto original = test_dataset::data_f32();
+
+        // Increase the number of threads to help a little with run time.
+        index.set_num_threads(2);
+        auto itr = svs::threads::UnitRange{0, index.size()};
+        auto valid_ids = std::unordered_set<size_t>{itr.begin(), itr.end()};
+        auto checker = DynamicChecker{valid_ids};
+        check(index, queries.cview(), gt.cview(), checker);
+
+        // Delete the best candidate for each of the test queries.
+        auto ids_to_delete = std::vector<size_t>();
+        for (size_t i = 0; i < QUERIES_TO_CHECK; ++i) {
+            auto nearest_neighbor = gt.get_datum(i).front();
+            auto itr =
+                std::find(ids_to_delete.begin(), ids_to_delete.end(), nearest_neighbor);
+            if (itr == ids_to_delete.end()) {
+                ids_to_delete.push_back(nearest_neighbor);
+                CATCH_REQUIRE(valid_ids.erase(nearest_neighbor) == 1);
+                CATCH_REQUIRE(checker.seen_.contains(nearest_neighbor));
+            }
+        }
+
+        fmt::print("Deleting\n");
+        index.delete_entries(ids_to_delete);
+        checker.clear();
+        check(index, queries.cview(), gt.cview(), checker);
+
+        for (auto id : ids_to_delete) {
+            CATCH_REQUIRE(!checker.seen_.contains(id));
+        }
+
+        // Compact and consolidate.
+        index.consolidate();
+        index.compact();
+
+        fmt::print("Compacting\n");
+        checker.clear();
+        check(index, queries.cview(), gt.cview(), checker);
+        for (auto id : ids_to_delete) {
+            CATCH_REQUIRE(!checker.seen_.contains(id));
+        }
+
+        // Add back the points we deleted and try again.
+        fmt::print("Adding\n");
+        auto slots = index.add_points(
+            svs::data::make_const_view(original, ids_to_delete), ids_to_delete
+        );
+
+        checker.clear();
+        for (auto id : ids_to_delete) {
+            auto [_, inserted] = valid_ids.insert(id);
+            CATCH_REQUIRE(inserted);
+        }
+
+        check(index, queries.cview(), gt.cview(), checker);
+        for (auto id : ids_to_delete) {
+            CATCH_REQUIRE(checker.seen_.contains(id));
+        }
+    }
+}

--- a/tests/svs/index/vamana/iterator_example.cpp
+++ b/tests/svs/index/vamana/iterator_example.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2024 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// svs
+#include "svs/orchestrators/vamana.h" // bulk of the dependencies required.
+
+// catch2
+#include "catch2/catch_test_macros.hpp"
+
+// stl
+#include <map>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+svs::data::SimpleData<float> initialize_example_data() {
+    // Create a dataset with 7 elements, each with 4 dimensions.
+    auto data = svs::data::SimpleData<float>(7, 4);
+
+    // Fill data `i` with all `i`s.
+    auto buffer = std::vector<float>();
+    for (size_t i = 0; i < data.size(); ++i) {
+        auto fi = svs::lib::narrow<float>(i);
+        buffer = {fi, fi, fi, fi};
+        data.set_datum(i, buffer);
+    }
+    return data;
+}
+
+svs::Vamana make_example_index() {
+    // Build the index.
+    auto build_parameters =
+        svs::index::vamana::VamanaBuildParameters{1.2, 16, 32, 16, 16, true};
+    return svs::Vamana::build<float>(
+        build_parameters, initialize_example_data(), svs::DistanceL2{}
+    );
+}
+
+void test_default_schedule() {
+    auto index = make_example_index();
+
+    // Base search parameters for the iterator schedule.
+    auto base_parameters = svs::index::vamana::VamanaSearchParameters{}.buffer_config({4});
+
+    // The default schedule take base parameters and a batch size.
+    // On each iteration,
+    auto schedule = svs::index::vamana::DefaultSchedule{base_parameters, 3};
+
+    // Create a batch iterator over the index for the query.
+    // After the constructor returns, the contents of the first batch will be available.
+    auto itr = [&]() {
+        // Construct a query a query in a scoped block to demonstrate that the iterator
+        // maintains an internal copy.
+        auto query = std::vector<float>{3.25, 3.25, 3.25, 3.25};
+        return index.batch_iterator(svs::lib::as_const_span(query), schedule);
+    }();
+
+    // The iterator was configured to yield three neighbors on each invocation.
+    // This information is available through the `size()` method.
+    CATCH_REQUIRE(itr.size() == 3);
+    // There are more neighbors to return.
+    CATCH_REQUIRE(!itr.done());
+    // The current batch of neighbors is for batch 0.
+    CATCH_REQUIRE(itr.batch() == 0);
+
+    // Obtain a view of the current list candidates.
+    std::span<const svs::Neighbor<size_t>> results = itr.results();
+    CATCH_REQUIRE(results.size() == 3);
+
+    // We constructed the dataset in such a way that we know what the results should be.
+    CATCH_REQUIRE(results[0].id() == 3);
+    CATCH_REQUIRE(results[1].id() == 4);
+    CATCH_REQUIRE(results[2].id() == 2);
+
+    // Once we've finished with the current batch of neighbors, we can step the iterator
+    // to the next batch.
+    //
+    // Using the `DefaultSchedule`, we will retrieve at most 3 new candidates.
+    itr.next();
+    CATCH_REQUIRE(itr.size() == 3);
+    CATCH_REQUIRE(!itr.done());
+    CATCH_REQUIRE(itr.batch() == 1);
+
+    results = itr.results();
+    CATCH_REQUIRE(results[0].id() == 5);
+    CATCH_REQUIRE(results[1].id() == 1);
+    CATCH_REQUIRE(results[2].id() == 6);
+
+    // So far, the iterator has yielded 6 of the 7 vectors in the dataset.
+    // This call to `next()` should only yield a single neighbor - the last on in the index.
+    itr.next();
+    CATCH_REQUIRE(itr.size() == 1);
+    CATCH_REQUIRE(itr.done());
+    CATCH_REQUIRE(itr.batch() == 2);
+    results = itr.results();
+    CATCH_REQUIRE(results[0].id() == 0);
+
+    // Calling `next()` again should yield no more candidates.
+    itr.next();
+    CATCH_REQUIRE(itr.size() == 0);
+    CATCH_REQUIRE(itr.batch() == 2);
+    CATCH_REQUIRE(itr.done());
+
+    itr.next();
+    CATCH_REQUIRE(itr.size() == 0);
+    CATCH_REQUIRE(itr.batch() == 2);
+    CATCH_REQUIRE(itr.done());
+
+    // Update with a new schedule.
+    {
+        auto newquery = std::vector<float>{2.25, 2.25, 2.25, 2.25};
+        auto schedule = svs::index::vamana::DefaultSchedule{base_parameters, 4};
+        itr.update(svs::lib::as_const_span(newquery), schedule);
+    }
+    CATCH_REQUIRE(itr.batch() == 0);
+    CATCH_REQUIRE(itr.size() == 4);
+    CATCH_REQUIRE(!itr.done());
+    results = itr.results();
+    CATCH_REQUIRE(results[0].id() == 2);
+    CATCH_REQUIRE(results[1].id() == 3);
+    CATCH_REQUIRE(results[2].id() == 1);
+    CATCH_REQUIRE(results[3].id() == 4);
+
+    itr.next();
+    CATCH_REQUIRE(itr.batch() == 1);
+    CATCH_REQUIRE(itr.size() == 3);
+    CATCH_REQUIRE(itr.done());
+
+    results = itr.results();
+    CATCH_REQUIRE(results[0].id() == 0);
+    CATCH_REQUIRE(results[1].id() == 5);
+    CATCH_REQUIRE(results[2].id() == 6);
+
+    itr.next();
+    CATCH_REQUIRE(itr.size() == 0);
+    CATCH_REQUIRE(itr.batch() == 1);
+    CATCH_REQUIRE(itr.done());
+
+    itr.next();
+    CATCH_REQUIRE(itr.size() == 0);
+    CATCH_REQUIRE(itr.batch() == 1);
+    CATCH_REQUIRE(itr.done());
+}
+} // namespace
+
+CATCH_TEST_CASE("Vamana Iterator Example", "[index][vamana][iterator]") {
+    test_default_schedule();
+}

--- a/tests/svs/index/vamana/iterator_schedule.cpp
+++ b/tests/svs/index/vamana/iterator_schedule.cpp
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2024 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// header under test
+#include "svs/index/vamana/iterator_schedule.h"
+
+// catch2
+#include "catch2/catch_test_macros.hpp"
+#include "catch2/matchers/catch_matchers_string.hpp"
+
+// tests
+#include "tests/utils/utils.h"
+
+namespace {
+
+template <typename T>
+concept IteratorSchedule = svs::index::vamana::IteratorSchedule<T>;
+
+// Functor computing `m * x + b` for unsigned `m, x, b`.
+struct Linear {
+    size_t operator()(size_t x) const { return m * x + b; }
+
+    size_t m;
+    size_t b;
+};
+
+template <IteratorSchedule Schedule>
+void test_default_schedule(
+    const Schedule& schedule,
+    size_t num_iterations,
+    const Linear& search_window_size,
+    const Linear& search_buffer_capacity,
+    size_t batch_size,
+    size_t prefetch_lookahead,
+    size_t prefetch_step
+) {
+    for (size_t i = 0; i < num_iterations; ++i) {
+        auto sp = schedule.for_iteration(i);
+        CATCH_REQUIRE(sp.buffer_config_.get_search_window_size() == search_window_size(i));
+        CATCH_REQUIRE(sp.buffer_config_.get_total_capacity() == search_buffer_capacity(i));
+        CATCH_REQUIRE(sp.search_buffer_visited_set_ == false);
+        CATCH_REQUIRE(sp.prefetch_lookahead_ == prefetch_lookahead);
+        CATCH_REQUIRE(sp.prefetch_step_ == prefetch_step);
+
+        CATCH_REQUIRE(schedule.max_candidates(i) == batch_size);
+    }
+}
+
+template <IteratorSchedule Schedule>
+void test_linear_schedule(
+    const Schedule& schedule,
+    size_t num_iterations,
+    const Linear& search_window_size,
+    const Linear& search_buffer_capacity,
+    const Linear& batch_size,
+    int64_t visited_after,
+    size_t prefetch_lookahead,
+    size_t prefetch_step
+) {
+    for (size_t i = 0; i < num_iterations; ++i) {
+        // Search Parameters
+        auto sp = schedule.for_iteration(i);
+        CATCH_REQUIRE(sp.buffer_config_.get_search_window_size() == search_window_size(i));
+        CATCH_REQUIRE(sp.buffer_config_.get_total_capacity() == search_buffer_capacity(i));
+        if (visited_after >= 0 && i >= svs::lib::narrow<size_t>(visited_after)) {
+            CATCH_REQUIRE(sp.search_buffer_visited_set_ == true);
+        } else {
+            CATCH_REQUIRE(sp.search_buffer_visited_set_ == false);
+        }
+
+        CATCH_REQUIRE(sp.prefetch_lookahead_ == prefetch_lookahead);
+        CATCH_REQUIRE(sp.prefetch_step_ == prefetch_step);
+
+        // Max Candidates
+        CATCH_REQUIRE(schedule.max_candidates(i) == batch_size(i));
+    }
+}
+
+} // namespace
+
+CATCH_TEST_CASE("Iterator Schedules", "[vamana][index][iterator][iterator_schedule]") {
+    using VSP = svs::index::vamana::VamanaSearchParameters;
+    using LS = svs::index::vamana::LinearSchedule;
+    CATCH_SECTION("Default Schedule") {
+        auto base = VSP{{10, 20}, false, 1, 4};
+        auto sched = svs::index::vamana::DefaultSchedule{base, 5};
+
+        // `for_iteration` interface.
+        CATCH_REQUIRE(sched.for_iteration(0) == base);
+        CATCH_REQUIRE(sched.for_iteration(1) == VSP{{15, 25}, false, 1, 4});
+        CATCH_REQUIRE(sched.for_iteration(2) == VSP{{20, 30}, false, 1, 4});
+        CATCH_REQUIRE(sched.for_iteration(3) == VSP{{25, 35}, false, 1, 4});
+
+        // `max_candidates` Interface.
+        CATCH_REQUIRE(sched.max_candidates(0) == 5);
+        CATCH_REQUIRE(sched.max_candidates(1) == 5);
+        CATCH_REQUIRE(sched.max_candidates(2) == 5);
+        CATCH_REQUIRE(sched.max_candidates(3) == 5);
+
+        test_default_schedule(sched, 4, {5, 10}, {5, 20}, 5, 1, 4);
+    }
+
+    CATCH_SECTION("Linear Schedule") {
+        auto base = VSP({10, 23}, false, 4, 0);
+        CATCH_SECTION("Invariants") {
+            // Buffer capacity scale must be greater than or equal to the capacity.
+            CATCH_REQUIRE_THROWS_MATCHES(
+                (LS{base, 20, 10, -1, 10, 0}),
+                svs::ANNException,
+                svs_test::ExceptionMatcher(
+                    Catch::Matchers::ContainsSubstring("Capacity scaling must be at least")
+                )
+            );
+
+            // Initial batch size must be non-zero.
+            CATCH_REQUIRE_THROWS_MATCHES(
+                (LS{base, 10, 10, -1, 0, 10}),
+                svs::ANNException,
+                svs_test::ExceptionMatcher(Catch::Matchers::ContainsSubstring(
+                    "Batch size start must be at least 1"
+                ))
+            );
+        }
+
+        // Minimal constructor - should behave like the default schedule.
+        test_default_schedule(LS{base, 4}, 4, {4, 10}, {4, 23}, 4, 4, 0);
+
+        auto ls = LS{base, 4, 5, 3, 2, 20};
+        test_linear_schedule(ls, 4, {4, 10}, {5, 23}, {20, 2}, 3, 4, 0);
+        /// buffer scaling
+        ls.buffer_scaling({5, 6});
+        test_linear_schedule(ls, 4, {5, 10}, {6, 23}, {20, 2}, 3, 4, 0);
+
+        /// visited set
+        ls.enable_filter_after(0);
+        test_linear_schedule(ls, 4, {5, 10}, {6, 23}, {20, 2}, 0, 4, 0);
+        ls.disable_filter();
+        test_linear_schedule(ls, 4, {5, 10}, {6, 23}, {20, 2}, -1, 4, 0);
+
+        /// starting batch size
+        ls.starting_batch_size(4);
+        test_linear_schedule(ls, 4, {5, 10}, {6, 23}, {20, 4}, -1, 4, 0);
+
+        // Should get an exception if misconfigured.
+        CATCH_REQUIRE_THROWS_MATCHES(
+            ls.starting_batch_size(0),
+            svs::ANNException,
+            svs_test::ExceptionMatcher(
+                Catch::Matchers::ContainsSubstring("Starting batch size must be nonzero.")
+            )
+        );
+
+        /// batch size scaling
+        ls.batch_size_scaling(3);
+        test_linear_schedule(ls, 4, {5, 10}, {6, 23}, {3, 4}, -1, 4, 0);
+
+        ls.disable_batch_size_scaling();
+        test_linear_schedule(ls, 4, {5, 10}, {6, 23}, {0, 4}, -1, 4, 0);
+    }
+
+    CATCH_SECTION("Abstract Iterator Schedule") {
+        using LS = svs::index::vamana::LinearSchedule;
+        auto base = VSP{{10, 20}, false, 1, 4};
+        auto sched = svs::index::vamana::DefaultSchedule{base, 5};
+        auto abstract = svs::index::vamana::AbstractIteratorSchedule{sched};
+
+        auto test_default = [](const auto& sched, size_t batchsize) {
+            test_default_schedule(
+                sched, 4, {batchsize, 10}, {batchsize, 20}, batchsize, 1, 4
+            );
+        };
+
+        test_default(sched, 5);
+        test_default(abstract, 5);
+
+        // Construct using `std::in_place_type`.
+        // Also test the move-assignment operator while we're at it.
+        abstract = svs::index::vamana::AbstractIteratorSchedule{
+            std::in_place_type<svs::index::vamana::DefaultSchedule>, base, size_t{10}};
+
+        test_default(abstract, 10);
+
+        // Copy constructor.
+        auto copy = abstract;
+        test_default(abstract, 10);
+
+        // Move assignment.
+        {
+            auto linear =
+                svs::index::vamana::AbstractIteratorSchedule{LS{base, 2}
+                                                                 .batch_size_scaling(20)
+                                                                 .buffer_scaling({4, 5})
+                                                                 .enable_filter_after(3)};
+            test_linear_schedule(linear, 4, {4, 10}, {5, 20}, {20, 2}, 3, 1, 4);
+            abstract = std::move(linear);
+            test_linear_schedule(abstract, 4, {4, 10}, {5, 20}, {20, 2}, 3, 1, 4);
+        }
+
+        // copy-assignment.
+        copy = abstract;
+        test_linear_schedule(copy, 4, {4, 10}, {5, 20}, {20, 2}, 3, 1, 4);
+
+        // move-construction
+        {
+            auto another_copy = std::move(copy);
+            test_linear_schedule(another_copy, 4, {4, 10}, {5, 20}, {20, 2}, 3, 1, 4);
+        }
+
+        // Reset
+        copy.reset(sched);
+        test_default(copy, 5);
+    }
+}

--- a/tests/svs/lib/scopeguard.cpp
+++ b/tests/svs/lib/scopeguard.cpp
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2023 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// svs
+#include "svs/lib/scopeguard.h"
+#include "svs/third-party/fmt.h"
+
+// catch2
+#include "catch2/catch_template_test_macros.hpp"
+#include "catch2/catch_test_macros.hpp"
+
+// stl
+#include <utility>
+
+///// Test Setup
+namespace {
+
+struct ScopeGuardCallback {
+  public:
+    ScopeGuardCallback() = default;
+    ScopeGuardCallback(size_t* external_calls)
+        : external_calls_{external_calls} {}
+
+    // Disable copy constructors.
+    ScopeGuardCallback(const ScopeGuardCallback&) = delete;
+    ScopeGuardCallback& operator=(const ScopeGuardCallback&) = delete;
+
+    ScopeGuardCallback(ScopeGuardCallback&&) = default;
+    ScopeGuardCallback& operator=(ScopeGuardCallback&&) = default;
+    ~ScopeGuardCallback() = default;
+
+    void operator()() noexcept {
+        ++local_calls_;
+        if (external_calls_ != nullptr) {
+            ++(*external_calls_);
+        }
+    }
+
+    // The const version only increments the global count (if one exists)
+    void operator()() const noexcept {
+        if (external_calls_ != nullptr) {
+            ++(*external_calls_);
+        }
+    }
+
+    ///// Members
+    size_t local_calls_ = 0;
+    size_t* external_calls_ = nullptr;
+};
+
+} // namespace
+
+CATCH_TEST_CASE("ScopeGuard static ssserts", "[lib][scopeguard]") {
+    CATCH_STATIC_REQUIRE(std::is_same_v<
+                         svs::lib::detail::deduce_scopeguard_parameter_t<size_t&&>,
+                         size_t>);
+    CATCH_STATIC_REQUIRE(std::is_same_v<
+                         svs::lib::detail::deduce_scopeguard_parameter_t<size_t&>,
+                         size_t&>);
+    CATCH_STATIC_REQUIRE(std::is_same_v<
+                         svs::lib::detail::deduce_scopeguard_parameter_t<const size_t&>,
+                         const size_t&>);
+}
+
+CATCH_TEMPLATE_TEST_CASE_SIG(
+    "ScopeGuard", "[lib][scopeguard]", ((bool Dismissable), Dismissable), false, true
+) {
+    auto make_guard = [](auto&& x) {
+        if constexpr (Dismissable) {
+            return svs::lib::make_dismissable_scope_guard(SVS_FWD(x));
+        } else {
+            return svs::lib::make_scope_guard(SVS_FWD(x));
+        }
+    };
+
+    CATCH_SECTION("Static Checks") {
+        using T = svs::lib::ScopeGuard<ScopeGuardCallback, Dismissable>;
+        static_assert(
+            !std::is_copy_constructible_v<T>, "Expected copy constructor to be deleted!"
+        );
+        static_assert(
+            !std::is_move_constructible_v<T>, "Expected move constructor to be deleted!"
+        );
+        static_assert(
+            !std::is_copy_assignable_v<T>,
+            "Expected copy assignment operator to be deleted!"
+        );
+        static_assert(
+            !std::is_move_assignable_v<T>,
+            "Expected move assignment operator to be deleted!"
+        );
+
+        // Trivial constructor should be deleted.
+        static_assert(
+            !std::is_default_constructible_v<T>,
+            "ScopeGuard should not be default constructible!"
+        );
+
+        // Cannot construct a non-reference scope-guard from an lvalue reference.
+        static_assert(
+            !std::is_constructible_v<T, ScopeGuardCallback&>,
+            "ScopeGuard should not attempt to copy its arguments!"
+        );
+        static_assert(
+            !std::is_constructible_v<T, const ScopeGuardCallback&>,
+            "ScopeGuard should not attempt to copy its arguments!"
+        );
+    }
+
+    CATCH_SECTION("Basic Behavior") {
+        size_t global = 0;
+        auto x = ScopeGuardCallback(&global);
+        CATCH_REQUIRE(x.local_calls_ == 0);
+        CATCH_REQUIRE(global == 0);
+        { auto g = svs::lib::ScopeGuard<ScopeGuardCallback&, Dismissable>(x); }
+        CATCH_REQUIRE(x.local_calls_ == 1);
+        CATCH_REQUIRE(global == 1);
+
+        if constexpr (Dismissable) {
+            // Dismissing the scope guard should have no effect.
+            {
+                auto g = svs::lib::ScopeGuard<ScopeGuardCallback&, Dismissable>(x);
+                g.dismiss();
+            }
+            CATCH_REQUIRE(x.local_calls_ == 1);
+            CATCH_REQUIRE(global == 1);
+        }
+
+        // Mutable Reference
+        {
+            auto g = make_guard(x);
+            using gT = decltype(g);
+            static_assert(std::is_same_v<typename gT::callback_type, ScopeGuardCallback&>);
+            static_assert(gT::is_reference);
+            // Make sure we don't have a space overhead for non-Dismissable scope guards
+            if constexpr (!Dismissable) {
+                static_assert(sizeof(gT) == sizeof(void*));
+            } else {
+                static_assert(sizeof(gT) > sizeof(void*));
+            }
+        }
+        CATCH_REQUIRE(x.local_calls_ == 2);
+        CATCH_REQUIRE(global == 2);
+
+        // If dismissable - ensure that dismissing works.
+        if constexpr (Dismissable) {
+            {
+                auto g = make_guard(x);
+                g.dismiss();
+            }
+            CATCH_REQUIRE(x.local_calls_ == 2);
+            CATCH_REQUIRE(global == 2);
+        }
+
+        // Const Reference
+        {
+            auto g = make_guard(std::as_const(x));
+            using gT = decltype(g);
+            static_assert(std::is_same_v<
+                          typename gT::callback_type,
+                          const ScopeGuardCallback&>);
+            static_assert(gT::is_reference);
+            if constexpr (!Dismissable) {
+                static_assert(sizeof(gT) == sizeof(void*));
+            } else {
+                static_assert(sizeof(gT) > sizeof(void*));
+            }
+        }
+        CATCH_REQUIRE(x.local_calls_ == 2);
+        CATCH_REQUIRE(global == 3);
+
+        // If dismissable - ensure that dismissing works.
+        if constexpr (Dismissable) {
+            {
+                auto g = make_guard(std::as_const(x));
+                g.dismiss();
+            }
+            CATCH_REQUIRE(x.local_calls_ == 2);
+            CATCH_REQUIRE(global == 3);
+        }
+
+        // Rvalue Reference
+        {
+            auto g = make_guard(ScopeGuardCallback(&global));
+            using gT = decltype(g);
+            static_assert(std::is_same_v<typename gT::callback_type, ScopeGuardCallback>);
+            static_assert(!gT::is_reference);
+            if constexpr (!Dismissable) {
+                static_assert(sizeof(gT) == sizeof(ScopeGuardCallback));
+            } else {
+                static_assert(sizeof(gT) > sizeof(ScopeGuardCallback));
+            }
+        }
+        CATCH_REQUIRE(global == 4);
+
+        if constexpr (Dismissable) {
+            {
+                auto g = make_guard(ScopeGuardCallback(&global));
+                g.dismiss();
+            }
+            CATCH_REQUIRE(global == 4);
+        }
+    }
+}

--- a/tests/utils/vamana_reference.cpp
+++ b/tests/utils/vamana_reference.cpp
@@ -43,4 +43,34 @@ const toml::table& parse_expected() {
     static toml::table expected = toml::parse_file(reference_path().native());
     return expected;
 }
+
+svs::index::vamana::VamanaIndex<
+    svs::graphs::SimpleGraph<uint32_t>,
+    svs::data::SimpleData<float>,
+    svs::DistanceL2>
+load_test_index() {
+    return svs::index::vamana::auto_assemble(
+        test_dataset::vamana_config_file(),
+        test_dataset::graph(),
+        test_dataset::data_f32(),
+        svs::DistanceL2(),
+        1
+    );
+}
+
+svs::index::vamana::MutableVamanaIndex<
+    svs::graphs::SimpleGraph<uint32_t>,
+    svs::data::SimpleData<float>,
+    svs::DistanceL2>
+load_dynamic_test_index() {
+    return svs::index::vamana::auto_dynamic_assemble(
+        test_dataset::vamana_config_file(),
+        test_dataset::graph(),
+        test_dataset::data_f32(),
+        svs::DistanceL2(),
+        1,
+        true // debug_load_from_static
+    );
+}
+
 } // namespace test_dataset::vamana

--- a/tests/utils/vamana_reference.h
+++ b/tests/utils/vamana_reference.h
@@ -16,9 +16,13 @@
 
 #pragma once
 
+// svs-test
+#include "tests/utils/test_dataset.h"
+
 // svsbenchmark
 #include "svs-benchmark/datasets.h"
 #include "svs-benchmark/vamana/test.h"
+#include "svs/index/vamana/dynamic_index.h"
 
 // svs
 #include "svs/core/distance.h"
@@ -76,6 +80,50 @@ expected_search_results(svs::DistanceType distance, const T& dataset) {
         throw ANNEXCEPTION("Got {} results when only one was expected!", results.size());
     }
     return results[0];
+}
+
+/// Load a test index with default contained types.
+svs::index::vamana::VamanaIndex<
+    svs::graphs::SimpleGraph<uint32_t>,
+    svs::data::SimpleData<float>,
+    svs::DistanceL2>
+load_test_index();
+
+/// Load a test index with a custom distance functor.
+template <typename Distance>
+svs::index::vamana::
+    VamanaIndex<svs::graphs::SimpleGraph<uint32_t>, svs::data::SimpleData<float>, Distance>
+    load_test_index(const Distance& distance) {
+    return svs::index::vamana::auto_assemble(
+        test_dataset::vamana_config_file(),
+        test_dataset::graph(),
+        test_dataset::data_f32(),
+        distance,
+        1
+    );
+}
+
+/// Load a test index with default contained types.
+svs::index::vamana::MutableVamanaIndex<
+    svs::graphs::SimpleGraph<uint32_t>,
+    svs::data::SimpleData<float>,
+    svs::DistanceL2>
+load_dynamic_test_index();
+
+template <typename Distance>
+svs::index::vamana::MutableVamanaIndex<
+    svs::graphs::SimpleGraph<uint32_t>,
+    svs::data::SimpleData<float>,
+    Distance>
+load_dynamic_test_index(const Distance& distance) {
+    return svs::index::vamana::auto_dynamic_assemble(
+        test_dataset::vamana_config_file(),
+        test_dataset::graph(),
+        test_dataset::data_f32(),
+        distance,
+        1,
+        true // debug_load_from_static
+    );
 }
 
 } // namespace test_dataset::vamana

--- a/tools/benchmark_inputs/vamana/iterator-input.toml
+++ b/tools/benchmark_inputs/vamana/iterator-input.toml
@@ -1,0 +1,102 @@
+# Copyright 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[vamana_iterator_v1]]
+__schema__ = 'svsbenchmark_vamana_iterator'
+__version__ = 'v0.0.0'
+config = '/export/data/datasets/indexes/dpr-1m/config/'
+data = '/export/data/datasets/indexes/dpr-1m/data/'
+distance = 'MIP'
+graph = '/export/data/datasets/indexes/dpr-1m/graph/'
+groundtruth = '/export/data/datasets/dpr/dpr_1m_groundtruth_ip_10k_1000neighors.ivecs'
+ndims = 768
+queries = '/export/data/datasets/dpr/dpr_queries_10k_f32.fvecs'
+query_type = 'float32'
+
+    [vamana_iterator_v1.dataset]
+    __schema__ = 'benchmark_dataset_abstract'
+    __version__ = 'v0.0.0'
+    kind = 'uncompressed'
+
+        [vamana_iterator_v1.dataset.dataset]
+        __schema__ = 'benchmark_dataset_uncompressed'
+        __version__ = 'v0.0.0'
+        data_type = 'float16'
+
+    [vamana_iterator_v1.parameters]
+    __schema__ = 'svsbenchamrk_isp'
+    __version__ = 'v0.0.0'
+    num_batches = 10
+    query_subsample = 1000
+    target_recalls = [ 0.9 ]
+
+        [[vamana_iterator_v1.parameters.schedules]]
+        __schema__ = 'svsbench_vamana_iter_schedule'
+        __version__ = 'v0.0.0'
+        batch_size_start = 10
+        enable_filter_after = -1
+        scale_batch_size = 0
+        scale_buffer_capacity = 10
+        scale_search_window = 10
+        restart_searches = true
+
+        [[vamana_iterator_v1.parameters.schedules]]
+        __schema__ = 'svsbench_vamana_iter_schedule'
+        __version__ = 'v0.0.0'
+        batch_size_start = 10
+        enable_filter_after = -1
+        scale_batch_size = 0
+        scale_buffer_capacity = 10
+        scale_search_window = 10
+        restart_searches = false
+
+        [[vamana_iterator_v1.parameters.schedules]]
+        __schema__ = 'svsbench_vamana_iter_schedule'
+        __version__ = 'v0.0.0'
+        batch_size_start = 10
+        enable_filter_after = 0
+        scale_batch_size = 0
+        scale_buffer_capacity = 10
+        scale_search_window = 10
+        restart_searches = false
+
+        [[vamana_iterator_v1.parameters.schedules]]
+        __schema__ = 'svsbench_vamana_iter_schedule'
+        __version__ = 'v0.0.0'
+        batch_size_start = 10
+        enable_filter_after = 1
+        scale_batch_size = 0
+        scale_buffer_capacity = 10
+        scale_search_window = 10
+        restart_searches = false
+
+        [[vamana_iterator_v1.parameters.schedules]]
+        __schema__ = 'svsbench_vamana_iter_schedule'
+        __version__ = 'v0.0.0'
+        batch_size_start = 10
+        enable_filter_after = 2
+        scale_batch_size = 0
+        scale_buffer_capacity = 10
+        scale_search_window = 10
+        restart_searches = false
+
+        [[vamana_iterator_v1.parameters.schedules]]
+        __schema__ = 'svsbench_vamana_iter_schedule'
+        __version__ = 'v0.0.0'
+        batch_size_start = 10
+        enable_filter_after = 3
+        scale_batch_size = 0
+        scale_buffer_capacity = 10
+        scale_search_window = 10
+        restart_searches = false


### PR DESCRIPTION
This implements the groundwork for a batch iterator for the low-level Vamana indexes. Conceptually, the batch iterator allows searches to be restarted, returning a new batch of `k` nearest neighbors that have not yet been yielded.

The batcher iterator provides C++ iterator interfaces `begin()` and `end()` over a buffer of new IDs. To yield new neighbors, search is effectively restarted with the search window size and search buffer capacity incremented by `k`, ensuring at least `k` new IDs can be obtained that were not part of previous searches. Filtering is performed post-search to ensure that unique ID's are available on the next calls to `begin()` and `end()`.

There are some low-hanging performance wins to be had.

* The current implementation basically restarts search every single time. Kick-starting search with previously yielded neighbors is probably a good idea, but is currently lacking an API on the index side.
* The search scratchspace is currently not cached between runs. This means that calls to `next()` must refix the query and allocate scratchspace as needed. The scratchspace is currently lacking an API to enable adapting to new search parameters. Once this is in place, caching should be straightforward to implement.

## Some other thoughts

Single search for the dynamic index is awkward. Single search uses the provided scratchspace and result are extracted from this scratchspace post-search. However, the dynamic index uses different internal and external IDs with different bit-widths. This makes it impossible to reuse the search buffer to store translated IDs. Currently, the iterator needs to detect if ID translation is required and perform translation manually. Options are:
  1. Augment the scratchspace with room for translated neighbors. I don't like this because (A) this would not be used for batch searches and (B) might result in excess moving around of data which makes me sad.
  2. Use some kind of lazy iterator to translate the ID's as they are extracted from the scratch space.  I think this approach is cool, but requires the scratchspace to contain a reference to the ID translation struct, which does not feel like the move to me.
  3. Require single-search to provide a destination span into which results will be written and making our current version of "search" for single queries more internal.

Of these, I like 3 the most as it has nice symmetry with our existing batch search functions.

## Remaining Tasks

- [x] Progressive output generation for benchmarking (saving results as they become available).
- [x] Add documentation page for the iterator and schedules.
- [x] Add APIs for the iterator to assign a new query and reset the internal state.
- [x] Detect when an iterator has exhausted the elements in the index, provide an API for detecting this, and use this information to short-circuit searches that would return no neighbors anyway.
- [ ] Allow the iterator to be constructed without kick-starting an initial search.
- [ ] Enable Python bindings support for batch iterator
- [ ] Eager error checking for number of groundtruth elements in benchmarking.
