### PR TITLE
Add support for custom thread pool

### DIFF
--- a/bindings/python/include/svs/python/manager.h
+++ b/bindings/python/include/svs/python/manager.h
@@ -82,11 +82,12 @@ Returns:
 
 template <typename Manager>
 void add_threading_interface(pybind11::class_<Manager>& manager) {
-    manager.def_property_readonly("can_change_threads", &Manager::can_change_threads);
     manager.def_property(
         "num_threads",
         &Manager::get_num_threads,
-        &Manager::set_num_threads,
+        [](Manager& self, int num_threads) {
+            self.set_threadpool(svs::threads::DefaultThreadPool(num_threads));
+        },
         "Read/Write (int): Get and set the number of threads used to process queries."
     );
 }

--- a/bindings/python/src/python_bindings.cpp
+++ b/bindings/python/src/python_bindings.cpp
@@ -204,12 +204,15 @@ Args:
 
     // Intel(R) MKL
     m.def(
-        "have_mkl", &svs::python::have_mkl, "Return whether or not svs is linked with Intel(R) MKL."
+        "have_mkl",
+        &svs::python::have_mkl,
+        "Return whether or not svs is linked with Intel(R) MKL."
     );
     m.def(
         "mkl_num_threads",
         &svs::python::mkl_num_threads,
-        "Return the number of threads used by Intel(R) MKL, or None if svs is not linked with Intel(R) MKL."
+        "Return the number of threads used by Intel(R) MKL, or None if svs is not linked "
+        "with Intel(R) MKL."
     );
 
     ///// Indexes

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -37,6 +37,7 @@ endfunction()
 create_simple_example(saveload test_saveload saveload.cpp)
 create_simple_example(types test_types types.cpp)
 create_simple_example(vamana_iterator test_vamana_iterator vamana_iterator.cpp)
+create_simple_example(custom_thread_pool test_custom_thread_pool custom_thread_pool.cpp)
 
 ## More complicated examples involving more extensive setup.
 

--- a/examples/cpp/custom_thread_pool.cpp
+++ b/examples/cpp/custom_thread_pool.cpp
@@ -16,29 +16,30 @@
 
 //! [Includes]
 // SVS Dependencies
-#include "svs/orchestrators/vamana.h"   // bulk of the dependencies required.
-#include "svs/core/recall.h"            // Convenient k-recall@n computation.
-#include "svs/lib/threads.h"            // Thread pool-related dependencies.
+#include "svs/core/recall.h"          // Convenient k-recall@n computation.
+#include "svs/lib/threads.h"          // Thread pool-related dependencies.
+#include "svs/orchestrators/vamana.h" // bulk of the dependencies required.
 
 // Alternative main definition
 #include "svsmain.h"
 
 // stl
+#include <future>
 #include <map>
+#include <queue>
 #include <string>
 #include <string_view>
 #include <vector>
-#include <queue>
-#include <future>
 //! [Includes]
 
 namespace {
 
 //! [Helper Utilities]
-template <typename T>
-struct MoC {
-    MoC(T&& rhs): obj(std::move(rhs)) {}
-    MoC(const MoC& other): obj(std::move(other.obj)) {}
+template <typename T> struct MoC {
+    MoC(T&& rhs)
+        : obj(std::move(rhs)) {}
+    MoC(const MoC& other)
+        : obj(std::move(other.obj)) {}
     T& get() { return obj; }
     mutable T obj;
 };
@@ -46,116 +47,105 @@ struct MoC {
 
 //! [Custom thread pool implementation]
 class CustomThreadPool {
-
   public:
-      explicit CustomThreadPool(size_t num_threads) {
-          threads_.reserve(num_threads);
-          for(size_t i = 0; i < num_threads; ++i) {
-              threads_.emplace_back([this]() {
-                  while(!stop_) {
-                      std::function<void()> task;
-                      {
-                          std::unique_lock lock(mtx_);
-                          while(queue_.empty() && !stop_) {
-                              cv_.wait(lock);
-                          }
-                          if(!queue_.empty()) {
-                              task = queue_.front();
-                              queue_.pop();
-                          }
-                      }
+    explicit CustomThreadPool(size_t num_threads) {
+        threads_.reserve(num_threads);
+        for (size_t i = 0; i < num_threads; ++i) {
+            threads_.emplace_back([this]() {
+                while (!stop_) {
+                    std::function<void()> task;
+                    {
+                        std::unique_lock lock(mtx_);
+                        while (queue_.empty() && !stop_) {
+                            cv_.wait(lock);
+                        }
+                        if (!queue_.empty()) {
+                            task = queue_.front();
+                            queue_.pop();
+                        }
+                    }
 
-                      if(task) {
-                          task();
-                      }
-                  }
-              });
-          }
-      }
+                    if (task) {
+                        task();
+                    }
+                }
+            });
+        }
+    }
 
-      CustomThreadPool(CustomThreadPool&&) = delete;
-      CustomThreadPool(const CustomThreadPool&) = delete;
-      CustomThreadPool& operator=(CustomThreadPool&&) = delete;
-      CustomThreadPool& operator=(const CustomThreadPool&) = delete;
+    CustomThreadPool(CustomThreadPool&&) = delete;
+    CustomThreadPool(const CustomThreadPool&) = delete;
+    CustomThreadPool& operator=(CustomThreadPool&&) = delete;
+    CustomThreadPool& operator=(const CustomThreadPool&) = delete;
 
-      ~CustomThreadPool() {
-          shutdown();
-          for(auto& t: threads_) {
-              t.join();
-          }
-      }
+    ~CustomThreadPool() {
+        shutdown();
+        for (auto& t : threads_) {
+            t.join();
+        }
+    }
 
-      template <typename C>
-      std::future<void> insert(C&& task) {
-          std::promise<void> prom;
-          std::future<void> fu = prom.get_future();
-          {
-              std::scoped_lock lock(mtx_);
-              queue_.push([moc=MoC{std::move(prom)}, task=std::forward<C>(task)]() mutable {
-                  task();
-                  moc.obj.set_value();
-              });
-          }
-          cv_.notify_one();
-          return fu;
-      }
+    template <typename C> std::future<void> insert(C&& task) {
+        std::promise<void> prom;
+        std::future<void> fu = prom.get_future();
+        {
+            std::scoped_lock lock(mtx_);
+            queue_.push([moc = MoC{std::move(prom)},
+                         task = std::forward<C>(task)]() mutable {
+                task();
+                moc.obj.set_value();
+            });
+        }
+        cv_.notify_one();
+        return fu;
+    }
 
-      size_t size() const {
-          return threads_.size();
-      }
+    size_t size() const { return threads_.size(); }
 
-      void shutdown() {
-          std::scoped_lock lock(mtx_);
-          stop_ = true;
-          cv_.notify_all();
-      }
+    void shutdown() {
+        std::scoped_lock lock(mtx_);
+        stop_ = true;
+        cv_.notify_all();
+    }
 
   private:
+    std::vector<std::thread> threads_;
+    std::mutex mtx_;
+    std::condition_variable cv_;
 
-      std::vector<std::thread> threads_;
-      std::mutex mtx_;
-      std::condition_variable cv_;
-
-      bool stop_{false};
-      std::queue<std::function<void()>> queue_;
+    bool stop_{false};
+    std::queue<std::function<void()>> queue_;
 };
 
 /////
 ///// The wrapper for CustomThreadPool to work on SVS
 /////
 class CustomThreadPoolWrapper {
-
   public:
+    CustomThreadPoolWrapper(size_t num_threads)
+        : threadpool_{std::make_unique<CustomThreadPool>(num_threads)} {}
 
-      CustomThreadPoolWrapper(size_t num_threads): threadpool_{std::make_unique<CustomThreadPool>(num_threads)} {
-      }
-
-      void parallel_for(std::function<void(size_t)> f, size_t n) {
+    void parallel_for(std::function<void(size_t)> f, size_t n) {
         std::vector<std::future<void>> futures;
         futures.reserve(n);
-        for(size_t i = 0; i < n; ++i) {
-            futures.emplace_back(threadpool_->insert([&f, i]() {
-                f(i);
-            }));
+        for (size_t i = 0; i < n; ++i) {
+            futures.emplace_back(threadpool_->insert([&f, i]() { f(i); }));
         }
 
         // wait until all tasks are finished
-        for(auto& fu: futures) {
+        for (auto& fu : futures) {
             fu.get();
         }
-      }
+    }
 
-      size_t size() const {
-          return threadpool_->size();
-      }
+    size_t size() const { return threadpool_->size(); }
 
   private:
-
-      std::unique_ptr<CustomThreadPool> threadpool_;
+    std::unique_ptr<CustomThreadPool> threadpool_;
 };
 static_assert(svs::threads::ThreadPool<CustomThreadPoolWrapper>);
 //! [Custom thread pool implementation]
-}
+} // namespace
 
 //! [Helper Utilities]
 double run_recall(
@@ -217,7 +207,10 @@ int svs_main(std::vector<std::string> args) {
     //! [Index Build]
     size_t num_threads = 4;
     svs::Vamana index = svs::Vamana::build<float>(
-        parameters, svs::VectorDataLoader<float>(data_vecs), svs::DistanceL2(), CustomThreadPoolWrapper(num_threads)
+        parameters,
+        svs::VectorDataLoader<float>(data_vecs),
+        svs::DistanceL2(),
+        CustomThreadPoolWrapper(num_threads)
     );
     //! [Index Build]
 

--- a/examples/cpp/custom_thread_pool.cpp
+++ b/examples/cpp/custom_thread_pool.cpp
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-//! [Example All]
-
 //! [Includes]
 // SVS Dependencies
-#include "svs/orchestrators/vamana.h"  // bulk of the dependencies required.
-#include "svs/core/recall.h"           // Convenient k-recall@n computation.
+#include "svs/orchestrators/vamana.h"   // bulk of the dependencies required.
+#include "svs/core/recall.h"            // Convenient k-recall@n computation.
+#include "svs/lib/threads.h"            // Thread pool-related dependencies.
 
 // Alternative main definition
 #include "svsmain.h"
@@ -29,7 +28,134 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include <queue>
+#include <future>
 //! [Includes]
+
+namespace {
+
+//! [Helper Utilities]
+template <typename T>
+struct MoC {
+    MoC(T&& rhs): obj(std::move(rhs)) {}
+    MoC(const MoC& other): obj(std::move(other.obj)) {}
+    T& get() { return obj; }
+    mutable T obj;
+};
+//! [Helper Utilities]
+
+//! [Custom thread pool implementation]
+class CustomThreadPool {
+
+  public:
+      explicit CustomThreadPool(size_t num_threads) {
+          threads_.reserve(num_threads);
+          for(size_t i = 0; i < num_threads; ++i) {
+              threads_.emplace_back([this]() {
+                  while(!stop_) {
+                      std::function<void()> task;
+                      {
+                          std::unique_lock lock(mtx_);
+                          while(queue_.empty() && !stop_) {
+                              cv_.wait(lock);
+                          }
+                          if(!queue_.empty()) {
+                              task = queue_.front();
+                              queue_.pop();
+                          }
+                      }
+
+                      if(task) {
+                          task();
+                      }
+                  }
+              });
+          }
+      }
+
+      CustomThreadPool(CustomThreadPool&&) = delete;
+      CustomThreadPool(const CustomThreadPool&) = delete;
+      CustomThreadPool& operator=(CustomThreadPool&&) = delete;
+      CustomThreadPool& operator=(const CustomThreadPool&) = delete;
+
+      ~CustomThreadPool() {
+          shutdown();
+          for(auto& t: threads_) {
+              t.join();
+          }
+      }
+
+      template <typename C>
+      std::future<void> insert(C&& task) {
+          std::promise<void> prom;
+          std::future<void> fu = prom.get_future();
+          {
+              std::scoped_lock lock(mtx_);
+              queue_.push([moc=MoC{std::move(prom)}, task=std::forward<C>(task)]() mutable {
+                  task();
+                  moc.obj.set_value();
+              });
+          }
+          cv_.notify_one();
+          return fu;
+      }
+
+      size_t size() const {
+          return threads_.size();
+      }
+
+      void shutdown() {
+          std::scoped_lock lock(mtx_);
+          stop_ = true;
+          cv_.notify_all();
+      }
+
+  private:
+
+      std::vector<std::thread> threads_;
+      std::mutex mtx_;
+      std::condition_variable cv_;
+
+      bool stop_{false};
+      std::queue<std::function<void()>> queue_;
+};
+
+/////
+///// The wrapper for CustomThreadPool to work on SVS
+/////
+class CustomThreadPoolWrapper {
+
+  public:
+
+      CustomThreadPoolWrapper(size_t num_threads): threadpool_{std::make_unique<CustomThreadPool>(num_threads)} {
+      }
+
+      void parallel_for(std::function<void(size_t)> f, size_t n) {
+        std::vector<std::future<void>> futures;
+        futures.reserve(n);
+        for(size_t i = 0; i < n; ++i) {
+            futures.emplace_back(threadpool_->insert([&f, i]() {
+                f(i);
+            }));
+        }
+
+        // wait until all tasks are finished
+        for(auto& fu: futures) {
+            fu.get();
+        }
+      }
+
+      size_t size() const {
+          return threadpool_->size();
+      }
+
+  private:
+
+      std::unique_ptr<CustomThreadPool> threadpool_;
+};
+static_assert(svs::threads::ThreadPool<CustomThreadPoolWrapper>);
+//! [Custom thread pool implementation]
+}
 
 //! [Helper Utilities]
 double run_recall(
@@ -91,7 +217,7 @@ int svs_main(std::vector<std::string> args) {
     //! [Index Build]
     size_t num_threads = 4;
     svs::Vamana index = svs::Vamana::build<float>(
-        parameters, svs::VectorDataLoader<float>(data_vecs), svs::DistanceL2(), num_threads
+        parameters, svs::VectorDataLoader<float>(data_vecs), svs::DistanceL2(), CustomThreadPoolWrapper(num_threads)
     );
     //! [Index Build]
 
@@ -152,9 +278,9 @@ int svs_main(std::vector<std::string> args) {
     );
     //! [Only Loading]
 
-    //! [Set a new thread pool with n-threads]
-    index.set_threadpool(svs::threads::DefaultThreadPool(4));
-    //! [Set a new thread pool with n-threads]
+    //! [Set a new thread pool]
+    index.set_threadpool(CustomThreadPoolWrapper(4));
+    //! [Set a new thread pool]
 
     return 0;
 }

--- a/examples/cpp/vamana.cpp
+++ b/examples/cpp/vamana.cpp
@@ -18,8 +18,8 @@
 
 //! [Includes]
 // SVS Dependencies
-#include "svs/orchestrators/vamana.h"  // bulk of the dependencies required.
-#include "svs/core/recall.h"           // Convenient k-recall@n computation.
+#include "svs/orchestrators/vamana.h" // bulk of the dependencies required.
+#include "svs/core/recall.h"          // Convenient k-recall@n computation.
 
 // Alternative main definition
 #include "svsmain.h"

--- a/include/svs/core/compact.h
+++ b/include/svs/core/compact.h
@@ -59,7 +59,7 @@ void compact_data(
         auto this_batch = batch_to_new.eachindex();
 
         // Copy from the original dataset into the buffer.
-        threads::run(
+        threads::parallel_for(
             threadpool,
             threads::StaticPartition(this_batch),
             [&](const auto& batch_ids, uint64_t SVS_UNUSED(tid)) {
@@ -71,7 +71,7 @@ void compact_data(
         );
 
         // Copy back from the buffer to the new location in the original dataset.
-        threads::run(
+        threads::parallel_for(
             threadpool,
             threads::StaticPartition(this_batch),
             [&](const auto& batch_ids, uint64_t SVS_UNUSED(tid)) {

--- a/include/svs/core/distance/euclidean.h
+++ b/include/svs/core/distance/euclidean.h
@@ -38,8 +38,8 @@
 // implementation based on the available extension.
 //
 // The vector width used is added as well in case there is an apparent mismatch between
-// Intel(R) AVX extension and the preferred vector width due to performance (sometimes, smaller
-// vector widths are faster).
+// Intel(R) AVX extension and the preferred vector width due to performance (sometimes,
+// smaller vector widths are faster).
 //
 // Versions for older extensions are implemented as fallbacks.
 //

--- a/include/svs/core/distance/simd_utils.h
+++ b/include/svs/core/distance/simd_utils.h
@@ -134,14 +134,14 @@ namespace simd {
 /// 2. Using multiple accumulators can really help in some situations. Floating point
 ///    arithmetic is not associative, so generally the compiler must strictly obey program
 ///    semantics when optimizing. This means that if a single accumulator register is used,
-///    we introduce a long chain dependency in the instruction stream. Intel(R) AVX functional
-///    units are generally pipelined and so have a relatively high latency (4 cycles is common)
-///    but with a high throughput.
+///    we introduce a long chain dependency in the instruction stream. Intel(R) AVX
+///    functional units are generally pipelined and so have a relatively high latency (4
+///    cycles is common) but with a high throughput.
 ///
 ///    For example: Cascadelake and greater servers have two execution port that offer the
-///    bulk of Intel(R) AVX-512 functionality. When fully utilized, SIMD instructions can obtain
-///    a throughput of 2 ops per cycle (separate from loads, which can sustain another 2 ops
-///    (3 ops on Sapphire Rapids) per cycle.
+///    bulk of Intel(R) AVX-512 functionality. When fully utilized, SIMD instructions can
+///    obtain a throughput of 2 ops per cycle (separate from loads, which can sustain
+///    another 2 ops (3 ops on Sapphire Rapids) per cycle.
 ///
 ///    A long dependence on a single accumulation register basically throws all that
 ///    horse-power away.

--- a/include/svs/core/kmeans.h
+++ b/include/svs/core/kmeans.h
@@ -48,12 +48,12 @@ Neighbor<size_t> find_nearest(const Query& query, const Data& data) {
     return nearest;
 }
 
-template <data::ImmutableMemoryDataset Data, data::ImmutableMemoryDataset Centroids>
+template <data::ImmutableMemoryDataset Data, data::ImmutableMemoryDataset Centroids, threads::ThreadPool Pool>
 double mean_squared_error(
-    const Data& data, const Centroids& centroids, threads::NativeThreadPool& threadpool
+    const Data& data, const Centroids& centroids, Pool& threadpool
 ) {
     threads::SequentialTLS<double> sums(0, threadpool.size());
-    threads::run(
+    threads::parallel_for(
         threadpool,
         threads::DynamicPartition{data.size(), 256},
         [&](auto indices, auto tid) {
@@ -99,14 +99,14 @@ struct KMeansParameters {
     size_t seed;
 };
 
-template <data::ImmutableMemoryDataset Data>
+template <data::ImmutableMemoryDataset Data, threads::ThreadPool Pool>
 void process_batch(
     const Data& data,
     data::SimpleData<float>& centroids,
     std::vector<int64_t>& counts,
     std::vector<int64_t>& old_counts,
     std::vector<size_t>& assignments,
-    threads::NativeThreadPool& threadpool,
+    Pool& threadpool,
     lib::Timer& timer
 ) {
     assignments.resize(data.size());
@@ -114,7 +114,7 @@ void process_batch(
     // Find the nearest centroid to each element in the sampled dataset.
     // Store the results in `assignments`.
     auto generate_assignments = timer.push_back("generate assignments");
-    threads::run(
+    threads::parallel_for(
         threadpool,
         threads::DynamicPartition{data.size(), 128},
         [&](auto indices, auto /*tid*/) {
@@ -143,11 +143,11 @@ void process_batch(
     adjust_centroids.finish();
 }
 
-template <data::ImmutableMemoryDataset Data, typename Callback = lib::donothing>
+template <data::ImmutableMemoryDataset Data, typename Callback = lib::donothing, threads::ThreadPool Pool>
 data::SimpleData<float> train_impl(
     const KMeansParameters& parameters,
     const Data& data,
-    threads::NativeThreadPool& threadpool,
+    Pool& threadpool,
     Callback&& post_epoch_callback = lib::donothing()
 ) {
     size_t ndims = data.dimensions();
@@ -207,16 +207,31 @@ data::SimpleData<float> train_impl(
 
 template <
     data::ImmutableMemoryDataset Data,
-    typename ThreadpoolProto,
+    typename ThreadPoolProto,
     typename Callback = lib::donothing>
 data::SimpleData<float> train(
     const KMeansParameters& parameters,
     const Data& data,
-    ThreadpoolProto&& threadpool_proto,
+    ThreadPoolProto threadpool_proto,
     Callback&& post_epoch_callback = lib::donothing()
 ) {
     auto threadpool =
-        threads::as_threadpool(std::forward<ThreadpoolProto>(threadpool_proto));
+        threads::as_threadpool(std::move(threadpool_proto));
+    return train_impl(
+        parameters, data, threadpool, std::forward<Callback>(post_epoch_callback)
+    );
+}
+
+template <
+    data::ImmutableMemoryDataset Data,
+    threads::ThreadPool Pool,
+    typename Callback = lib::donothing>
+data::SimpleData<float> train(
+    const KMeansParameters& parameters,
+    const Data& data,
+    Pool& threadpool,
+    Callback&& post_epoch_callback = lib::donothing()
+) {
     return train_impl(
         parameters, data, threadpool, std::forward<Callback>(post_epoch_callback)
     );

--- a/include/svs/core/kmeans.h
+++ b/include/svs/core/kmeans.h
@@ -48,10 +48,11 @@ Neighbor<size_t> find_nearest(const Query& query, const Data& data) {
     return nearest;
 }
 
-template <data::ImmutableMemoryDataset Data, data::ImmutableMemoryDataset Centroids, threads::ThreadPool Pool>
-double mean_squared_error(
-    const Data& data, const Centroids& centroids, Pool& threadpool
-) {
+template <
+    data::ImmutableMemoryDataset Data,
+    data::ImmutableMemoryDataset Centroids,
+    threads::ThreadPool Pool>
+double mean_squared_error(const Data& data, const Centroids& centroids, Pool& threadpool) {
     threads::SequentialTLS<double> sums(0, threadpool.size());
     threads::parallel_for(
         threadpool,
@@ -143,7 +144,10 @@ void process_batch(
     adjust_centroids.finish();
 }
 
-template <data::ImmutableMemoryDataset Data, typename Callback = lib::donothing, threads::ThreadPool Pool>
+template <
+    data::ImmutableMemoryDataset Data,
+    typename Callback = lib::donothing,
+    threads::ThreadPool Pool>
 data::SimpleData<float> train_impl(
     const KMeansParameters& parameters,
     const Data& data,
@@ -215,8 +219,7 @@ data::SimpleData<float> train(
     ThreadPoolProto threadpool_proto,
     Callback&& post_epoch_callback = lib::donothing()
 ) {
-    auto threadpool =
-        threads::as_threadpool(std::move(threadpool_proto));
+    auto threadpool = threads::as_threadpool(std::move(threadpool_proto));
     return train_impl(
         parameters, data, threadpool, std::forward<Callback>(post_epoch_callback)
     );

--- a/include/svs/core/medioid.h
+++ b/include/svs/core/medioid.h
@@ -248,7 +248,7 @@ std::vector<double> op_pairwise(
 
     // Threaded run.
     threads::SequentialTLS<Op> tls{op.similar(), threadpool.size()};
-    threads::run(
+    threads::parallel_for(
         threadpool,
         threads::DynamicPartition(data.size(), batchsize),
         [&](const auto& indices, uint64_t tid) {
@@ -306,7 +306,7 @@ size_t find_medioid(
         type_traits::sentinel_v<Neighbor<size_t>, std::less<>>, threadpool.size()
     );
 
-    threads::run(
+    threads::parallel_for(
         threadpool,
         threads::StaticPartition{data.size()},
         [&](const auto& ids, uint64_t tid) {
@@ -348,7 +348,7 @@ size_t find_medioid(
 ///
 template <data::ImmutableMemoryDataset Data, typename... Args>
 size_t find_medioid(const Data& data, size_t num_threads, Args&&... args) {
-    auto threadpool = threads::NativeThreadPool(num_threads);
+    auto threadpool = threads::DefaultThreadPool(num_threads);
     return find_medioid(data, threadpool, std::forward<Args>(args)...);
 }
 

--- a/include/svs/index/flat/flat.h
+++ b/include/svs/index/flat/flat.h
@@ -184,15 +184,12 @@ class FlatIndex {
     ///     of the passed argument.
     /// @param distance The distance functor to use to compare queries with dataset
     ///     elements.
-    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable threadpool
+    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable thread pool
     ///     instance or an integer specifying the number of threads to use. In the latter case, a new
     ///     default thread pool will be constructed using ``threadpool_proto`` as the number of
     ///     threads to create.
     ///
-    /// The thread pool should implement two functions:
-    /// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
-    /// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
-    /// and ``n`` represents the number of partitions that need to be executed.
+    /// @copydoc threadpool_requirements
     ///
     template <typename ThreadPoolProto>
     FlatIndex(Data data, Dist distance, ThreadPoolProto threadpool_proto)
@@ -423,10 +420,7 @@ class FlatIndex {
     ///
     /// @param threadpool An acceptable thread pool.
     ///
-    /// The thread pool should implement two functions:
-    /// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
-    /// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
-    /// and ``n`` represents the number of partitions that need to be executed.
+    /// @copydoc threadpool_requirements
     ///
     template <threads::ThreadPool Pool>
     void set_threadpool(Pool threadpool) requires (!std::is_same_v<Pool, threads::ThreadPoolHandle>) {
@@ -458,7 +452,7 @@ class FlatIndex {
 /// @param data_proto Data prototype. See expanded notes.
 /// @param distance The distance **functor** to use to compare queries with elements of the
 ///     dataset.
-/// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable threadpool
+/// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable thread pool
 ///     instance or an integer specifying the number of threads to use. In the latter case, a new
 ///     default thread pool will be constructed using ``threadpool_proto`` as the number of
 ///     threads to create.
@@ -468,10 +462,7 @@ class FlatIndex {
 ///
 /// @copydoc hidden_flat_auto_assemble
 ///
-/// The thread pool should implement two functions:
-/// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
-/// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
-/// and ``n`` represents the number of partitions that need to be executed.
+/// @copydoc threadpool_requirements
 ///
 template <typename DataProto, typename Distance, typename ThreadPoolProto>
 auto auto_assemble(

--- a/include/svs/index/flat/flat.h
+++ b/include/svs/index/flat/flat.h
@@ -184,10 +184,11 @@ class FlatIndex {
     ///     of the passed argument.
     /// @param distance The distance functor to use to compare queries with dataset
     ///     elements.
-    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable thread pool
-    ///     instance or an integer specifying the number of threads to use. In the latter case, a new
-    ///     default thread pool will be constructed using ``threadpool_proto`` as the number of
-    ///     threads to create.
+    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an
+    /// acceptable thread pool
+    ///     instance or an integer specifying the number of threads to use. In the latter
+    ///     case, a new default thread pool will be constructed using ``threadpool_proto``
+    ///     as the number of threads to create.
     ///
     /// @copydoc threadpool_requirements
     ///
@@ -225,9 +226,11 @@ class FlatIndex {
     ///     ``num_neighbors`` is computed from the number of columns in ``result``.
     /// @param queries A dense collection of queries in R^n.
     /// @param search_parameters search parameters to use for the search.
-    /// @param cancel A predicate called during the search to determine if the search should be cancelled.
-    //      Return ``true`` if the search should be cancelled. This functor must implement ``bool operator()()``.
-    //      Note: This predicate should be thread-safe as it can be called concurrently by different threads during the search.
+    /// @param cancel A predicate called during the search to determine if the search should
+    /// be cancelled.
+    //      Return ``true`` if the search should be cancelled. This functor must implement
+    //      ``bool operator()()``. Note: This predicate should be thread-safe as it can be
+    //      called concurrently by different threads during the search.
     /// @param predicate A predicate functor that can be used to exclude certain dataset
     ///     elements from consideration. This functor must implement
     ///     ``bool operator()(size_t)`` where the ``size_t`` argument is an index in
@@ -423,7 +426,9 @@ class FlatIndex {
     /// @copydoc threadpool_requirements
     ///
     template <threads::ThreadPool Pool>
-    void set_threadpool(Pool threadpool) requires (!std::is_same_v<Pool, threads::ThreadPoolHandle>) {
+    void set_threadpool(Pool threadpool)
+        requires(!std::is_same_v<Pool, threads::ThreadPoolHandle>)
+    {
         set_threadpool(threads::ThreadPoolHandle(std::move(threadpool)));
     }
 
@@ -452,10 +457,11 @@ class FlatIndex {
 /// @param data_proto Data prototype. See expanded notes.
 /// @param distance The distance **functor** to use to compare queries with elements of the
 ///     dataset.
-/// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable thread pool
-///     instance or an integer specifying the number of threads to use. In the latter case, a new
-///     default thread pool will be constructed using ``threadpool_proto`` as the number of
-///     threads to create.
+/// @param threadpool_proto Precursor for the thread pool to use. Can either be an
+/// acceptable thread pool
+///     instance or an integer specifying the number of threads to use. In the latter case,
+///     a new default thread pool will be constructed using ``threadpool_proto`` as the
+///     number of threads to create.
 ///
 /// This method provides much of the heavy lifting for constructing a Flat index from
 /// a data file on disk or a dataset in memory.
@@ -480,7 +486,8 @@ using TemporaryFlatIndex = FlatIndex<Data, Dist, ReferencesMembers>;
 template <data::ImmutableMemoryDataset Data, typename Dist, typename ThreadPoolProto>
 TemporaryFlatIndex<Data, Dist>
 temporary_flat_index(Data& data, Dist distance, ThreadPoolProto threadpool_proto) {
-    return TemporaryFlatIndex<Data, Dist>{data, distance, threads::as_threadpool(std::move(threadpool_proto))};
+    return TemporaryFlatIndex<Data, Dist>{
+        data, distance, threads::as_threadpool(std::move(threadpool_proto))};
 }
 
 } // namespace svs::index::flat

--- a/include/svs/index/flat/flat.h
+++ b/include/svs/index/flat/flat.h
@@ -72,14 +72,14 @@ data::GetDatumAccessor svs_invoke(svs::tag_t<accessor>, const Data& SVS_UNUSED(d
 } // namespace extensions
 
 // The flat index is "special" because we wish to enable the `FlatIndex` to either:
-// (1) Own the data and thread pool.
-// (2) Reference an existing dataset and thread pool.
+// (1) Own the data.
+// (2) Reference an existing dataset.
 //
 // The latter option allows other index implementations like the VamanaIndex to launch a
 // scoped `FlatIndex` to perform exhaustive searches on demand (useful when validating
 // the behavior of the dynamic index).
 //
-// To that end, we allow the actual storage of the data and the threadpool to either be
+// To that end, we allow the actual storage of the data to either be
 // owning (by value) or non-owning (by reference).
 struct OwnsMembers {
     template <typename T> using storage_type = T;
@@ -130,7 +130,6 @@ class FlatIndex {
     using distance_type = Dist;
     /// The type of dataset.
     using data_type = Data;
-    using thread_pool_type = threads::NativeThreadPool;
     using compare = distance::compare_t<Dist>;
     using sorter_type = BulkInserter<Neighbor<size_t>, compare>;
 
@@ -138,7 +137,6 @@ class FlatIndex {
 
     // Compute data and threadpool storage types.
     using data_storage_type = storage_type_t<Ownership, Data>;
-    using thread_storage_type = storage_type_t<Ownership, thread_pool_type>;
 
     // Search parameters
     using search_parameters_type = FlatParameters;
@@ -146,7 +144,7 @@ class FlatIndex {
   private:
     data_storage_type data_;
     [[no_unique_address]] distance_type distance_;
-    thread_storage_type threadpool_;
+    threads::ThreadPoolHandle threadpool_;
 
     // Constructs controlling the iteration strategy over the data and queries.
     search_parameters_type search_parameters_{};
@@ -182,32 +180,33 @@ class FlatIndex {
     ///
     /// @brief Construct a new index from constituent parts.
     ///
-    /// @tparam ThreadPoolProto The type of the threadpool proto type. See notes on the
-    ///     corresponding parameter below.
-    ///
     /// @param data The data to use for the index. The resulting index will take ownership
     ///     of the passed argument.
     /// @param distance The distance functor to use to compare queries with dataset
     ///     elements.
-    /// @param threadpool_proto Something that can be used to build a threadpool using
-    ///     ``threads::as_threadpool``. In practice, this means that ``threapool_proto``
-    ///     can be either a threadpool directly, or an integer. In the latter case, a new
-    ///     threadpool will be constructed using ``threadpool_proto`` as the number of
+    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable threadpool
+    ///     instance or an integer specifying the number of threads to use. In the latter case, a new
+    ///     default thread pool will be constructed using ``threadpool_proto`` as the number of
     ///     threads to create.
     ///
+    /// The thread pool should implement two functions:
+    /// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
+    /// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
+    /// and ``n`` represents the number of partitions that need to be executed.
+    ///
     template <typename ThreadPoolProto>
-    FlatIndex(Data data, Dist distance, ThreadPoolProto&& threadpool_proto)
+    FlatIndex(Data data, Dist distance, ThreadPoolProto threadpool_proto)
         requires std::is_same_v<Ownership, OwnsMembers>
         : data_{std::move(data)}
         , distance_{std::move(distance)}
-        , threadpool_{
-              threads::as_threadpool(std::forward<ThreadPoolProto>(threadpool_proto))} {}
+        , threadpool_{threads::as_threadpool(std::move(threadpool_proto))} {}
 
-    FlatIndex(Data& data, Dist distance, threads::NativeThreadPool& threadpool)
+    template <typename ThreadPoolProto>
+    FlatIndex(Data& data, Dist distance, ThreadPoolProto threadpool_proto)
         requires std::is_same_v<Ownership, ReferencesMembers>
         : data_{data}
         , distance_{std::move(distance)}
-        , threadpool_{threadpool} {}
+        , threadpool_{threads::as_threadpool(std::move(threadpool_proto))} {}
 
     ////// Dataset Interface
 
@@ -305,7 +304,7 @@ class FlatIndex {
         // Perform any necessary post-processing on the sorting network and write back
         // the results.
         scratch.cleanup();
-        threads::run(
+        threads::parallel_for(
             threadpool_,
             threads::StaticPartition(queries.size()),
             [&](const auto& query_indices, uint64_t /*tid*/) {
@@ -329,7 +328,7 @@ class FlatIndex {
         Pred predicate = lib::Returns(lib::Const<true>())
     ) {
         // Process all queries.
-        threads::run(
+        threads::parallel_for(
             threadpool_,
             threads::DynamicPartition{
                 queries.size(),
@@ -409,29 +408,35 @@ class FlatIndex {
 
     // Threading Interface
 
-    /// Return whether this implementation can dynamically change the number of threads.
-    static bool can_change_threads() { return true; }
-
     ///
     /// @brief Return the current number of threads used for search.
     ///
     /// @sa set_num_threads
     size_t get_num_threads() const { return threadpool_.size(); }
 
-    ///
-    /// @brief Set the number of threads used for search.
-    ///
-    /// @param num_threads The new number of threads to use.
-    ///
-    /// Implementation note: The number of threads cannot be zero. If zero is passed to
-    /// this method, it will be silently changed to 1.
-    ///
-    /// @sa get_num_threads
-    ///
-    void set_num_threads(size_t num_threads) {
-        num_threads = std::max(num_threads, size_t(1));
-        threadpool_.resize(num_threads);
+    void set_threadpool(threads::ThreadPoolHandle threadpool) {
+        threadpool_ = std::move(threadpool);
     }
+
+    ///
+    /// @brief Destroy the original thread pool and set to the provided one.
+    ///
+    /// @param threadpool An acceptable thread pool.
+    ///
+    /// The thread pool should implement two functions:
+    /// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
+    /// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
+    /// and ``n`` represents the number of partitions that need to be executed.
+    ///
+    template <threads::ThreadPool Pool>
+    void set_threadpool(Pool threadpool) requires (!std::is_same_v<Pool, threads::ThreadPoolHandle>) {
+        set_threadpool(threads::ThreadPoolHandle(std::move(threadpool)));
+    }
+
+    ///
+    /// @brief Return the current thread pool handle.
+    ///
+    threads::ThreadPoolHandle& get_threadpool_handle() { return threadpool_; }
 };
 
 ///
@@ -453,19 +458,26 @@ class FlatIndex {
 /// @param data_proto Data prototype. See expanded notes.
 /// @param distance The distance **functor** to use to compare queries with elements of the
 ///     dataset.
-/// @param threadpool_proto Precursor for the thread pool to use. Can either be a threadpool
-///     instance of an integer specifying the number of threads to use.
+/// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable threadpool
+///     instance or an integer specifying the number of threads to use. In the latter case, a new
+///     default thread pool will be constructed using ``threadpool_proto`` as the number of
+///     threads to create.
 ///
 /// This method provides much of the heavy lifting for constructing a Flat index from
 /// a data file on disk or a dataset in memory.
 ///
 /// @copydoc hidden_flat_auto_assemble
 ///
+/// The thread pool should implement two functions:
+/// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
+/// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
+/// and ``n`` represents the number of partitions that need to be executed.
+///
 template <typename DataProto, typename Distance, typename ThreadPoolProto>
 auto auto_assemble(
     DataProto&& data_proto, Distance distance, ThreadPoolProto threadpool_proto
 ) {
-    auto threadpool = threads::as_threadpool(threadpool_proto);
+    auto threadpool = threads::as_threadpool(std::move(threadpool_proto));
     auto data = svs::detail::dispatch_load(std::forward<DataProto>(data_proto), threadpool);
     return FlatIndex(std::move(data), std::move(distance), std::move(threadpool));
 }
@@ -474,10 +486,10 @@ auto auto_assemble(
 template <data::ImmutableMemoryDataset Data, typename Dist>
 using TemporaryFlatIndex = FlatIndex<Data, Dist, ReferencesMembers>;
 
-template <data::ImmutableMemoryDataset Data, typename Dist>
+template <data::ImmutableMemoryDataset Data, typename Dist, typename ThreadPoolProto>
 TemporaryFlatIndex<Data, Dist>
-temporary_flat_index(Data& data, Dist distance, threads::NativeThreadPool& threadpool) {
-    return TemporaryFlatIndex<Data, Dist>{data, distance, threadpool};
+temporary_flat_index(Data& data, Dist distance, ThreadPoolProto threadpool_proto) {
+    return TemporaryFlatIndex<Data, Dist>{data, distance, threads::as_threadpool(std::move(threadpool_proto))};
 }
 
 } // namespace svs::index::flat

--- a/include/svs/index/inverted/clustering.h
+++ b/include/svs/index/inverted/clustering.h
@@ -739,7 +739,7 @@ void post_process_neighbors(
             }
         }
     };
-    threads::run(threadpool, threads::StaticPartition(results.n_queries()), impl);
+    threads::parallel_for(threadpool, threads::StaticPartition(results.n_queries()), impl);
 }
 
 template <typename Index, std::integral I> struct ClusteringSetup {
@@ -768,13 +768,13 @@ ClusteringSetup(Index, std::vector<I, lib::Allocator<I>>) -> ClusteringSetup<Ind
 /// NOTE: The resulting search index will not automatically perform conversion from index
 /// local IDs to global dataset IDs.
 ///
-template <data::ImmutableMemoryDataset Data, typename Distance, std::integral I>
+template <data::ImmutableMemoryDataset Data, typename Distance, std::integral I, threads::ThreadPool Pool>
 auto build_primary_index(
     const Data& data,
     std::span<const I> ids,
     const vamana::VamanaBuildParameters& vamana_parameters,
     const Distance& distance,
-    threads::ThreadPool auto threadpool
+    Pool threadpool
 ) {
     return vamana::auto_build(
         vamana_parameters,
@@ -842,7 +842,7 @@ Clustering<I> cluster_with(
             primary_index.get_distance(),
             local_translator,
             [centroid_ids](size_t i) { return centroid_ids[i]; },
-            primary_index.borrow_threadpool()
+            primary_index.get_threadpool_handle()
         );
         start = stop;
     }

--- a/include/svs/index/inverted/clustering.h
+++ b/include/svs/index/inverted/clustering.h
@@ -768,7 +768,11 @@ ClusteringSetup(Index, std::vector<I, lib::Allocator<I>>) -> ClusteringSetup<Ind
 /// NOTE: The resulting search index will not automatically perform conversion from index
 /// local IDs to global dataset IDs.
 ///
-template <data::ImmutableMemoryDataset Data, typename Distance, std::integral I, threads::ThreadPool Pool>
+template <
+    data::ImmutableMemoryDataset Data,
+    typename Distance,
+    std::integral I,
+    threads::ThreadPool Pool>
 auto build_primary_index(
     const Data& data,
     std::span<const I> ids,

--- a/include/svs/index/inverted/memory_based.h
+++ b/include/svs/index/inverted/memory_based.h
@@ -371,10 +371,7 @@ template <typename Index, typename Cluster> class InvertedIndex {
     ///
     /// @param threadpool An acceptable thread pool.
     ///
-    /// The thread pool should implement two functions:
-    /// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
-    /// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
-    /// and ``n`` represents the number of partitions that need to be executed.
+    /// @copydoc threadpool_requirements
     ///
     template <threads::ThreadPool Pool>
     void set_threadpool(Pool threadpool) requires (!std::is_same_v<Pool, threads::ThreadPoolHandle>) {

--- a/include/svs/index/inverted/memory_based.h
+++ b/include/svs/index/inverted/memory_based.h
@@ -337,11 +337,12 @@ template <typename Index, typename Cluster> class InvertedIndex {
     using translator_type = std::vector<index_type, lib::Allocator<index_type>>;
     using search_parameters_type = InvertedSearchParameters;
 
+    template <threads::ThreadPool Pool>
     InvertedIndex(
         Index index,
         Cluster cluster,
         translator_type index_local_to_global,
-        threads::NativeThreadPool threadpool
+        Pool threadpool
     )
         : index_{std::move(index)}
         , cluster_{std::move(cluster)}
@@ -349,15 +350,41 @@ template <typename Index, typename Cluster> class InvertedIndex {
         , threadpool_{std::move(threadpool)} {
         // Clear out the threadpool in the inner index - prefer to handle threading
         // ourselves.
-        index_.set_num_threads(1);
+        index_.set_threadpool(threads::SequentialThreadPool());
     }
 
     ///// Threading
-    static constexpr bool can_change_threads() { return true; }
-    size_t get_num_threads() const { return threadpool_.size(); }
-    void set_num_threads(size_t num_threads) {
-        threadpool_.resize(std::max<size_t>(num_threads, 1));
+
+    ///
+    /// @brief Return the current number of threads used for search.
+    ///
+    size_t get_num_threads() const {
+        return threadpool_.size();
     }
+
+    void set_threadpool(threads::ThreadPoolHandle threadpool) {
+        threadpool_ = std::move(threadpool);
+    }
+
+    ///
+    /// @brief Destroy the original thread pool and set to the provided one.
+    ///
+    /// @param threadpool An acceptable thread pool.
+    ///
+    /// The thread pool should implement two functions:
+    /// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
+    /// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
+    /// and ``n`` represents the number of partitions that need to be executed.
+    ///
+    template <threads::ThreadPool Pool>
+    void set_threadpool(Pool threadpool) requires (!std::is_same_v<Pool, threads::ThreadPoolHandle>) {
+        set_threadpool(threads::ThreadPoolHandle(std::move(threadpool)));
+    }
+
+    ///
+    /// @brief Return the current thread pool handle.
+    ///
+    threads::ThreadPoolHandle& get_threadpool_handle() { return threadpool_; }
 
     size_t size() const {
         // TODO: Fix
@@ -384,7 +411,7 @@ template <typename Index, typename Cluster> class InvertedIndex {
         const search_parameters_type& search_parameters,
         const lib::DefaultPredicate& cancel = lib::Returns(lib::Const<false>())
     ) {
-        threads::run(
+        threads::parallel_for(
             threadpool_,
             threads::StaticPartition(queries.size()),
             [&](auto is, auto SVS_UNUSED(tid)) {
@@ -481,7 +508,7 @@ template <typename Index, typename Cluster> class InvertedIndex {
     translator_type index_local_to_global_;
 
     // Transient parameters.
-    threads::NativeThreadPool threadpool_;
+    threads::ThreadPoolHandle threadpool_;
 };
 
 struct PickRandomly {
@@ -515,7 +542,7 @@ inline constexpr ClusteringPostOp no_clustering_post_op{};
 template <
     typename DataProto,
     typename Distance,
-    typename ThreadpoolProto,
+    typename ThreadPoolProto,
     StorageStrategy Strategy = SparseStrategy,
     typename CentroidPicker = PickRandomly,
     typename ClusteringOp = ClusteringPostOp>
@@ -523,7 +550,7 @@ auto auto_build(
     const inverted::InvertedBuildParameters& parameters,
     DataProto data_proto,
     Distance distance,
-    ThreadpoolProto threadpool_proto,
+    ThreadPoolProto threadpool_proto,
     // Customizations
     Strategy strategy = {},
     CentroidPicker centroid_picker = {},
@@ -532,7 +559,6 @@ auto auto_build(
     // Perform clustering.
     auto threadpool = threads::as_threadpool(std::move(threadpool_proto));
     auto data = svs::detail::dispatch_load(std::move(data_proto), threadpool);
-    size_t num_threads = threadpool.size();
 
     // Select Centroids.
     auto centroids =
@@ -557,15 +583,19 @@ auto auto_build(
     clustering_op(clustering);
 
     // Put together the final pieces.
+    // Note:
+    // We could move the primary threadpool to InvertedIndex.
+    // That thread pool will be reset in InvertedIndex anyway.
+    auto primary_threadpool = std::move(index.get_threadpool_handle());
     return InvertedIndex{
         std::move(index),
         strategy(data, clustering, HugepageAllocator<std::byte>()),
         std::move(centroids),
-        threads::NativeThreadPool(num_threads)};
+        std::move(primary_threadpool)};
 }
 
 ///// Auto Assembling.
-template <typename DataProto, typename Distance, StorageStrategy Strategy>
+template <typename DataProto, typename Distance, StorageStrategy Strategy, typename ThreadPoolProto>
 auto assemble_from_clustering(
     const std::filesystem::path& clustering_path,
     DataProto data_proto,
@@ -573,9 +603,9 @@ auto assemble_from_clustering(
     Strategy strategy,
     const std::filesystem::path& index_config,
     const std::filesystem::path& graph,
-    size_t num_threads
+    ThreadPoolProto threadpool_proto
 ) {
-    auto threadpool = threads::as_threadpool(num_threads);
+    auto threadpool = threads::as_threadpool(std::move(threadpool_proto));
     auto original = svs::detail::dispatch_load(std::move(data_proto), threadpool);
     auto clustering = lib::load_from_disk<Clustering<uint32_t>>(clustering_path);
     auto ids = clustering.sorted_centroids();

--- a/include/svs/index/inverted/memory_based.h
+++ b/include/svs/index/inverted/memory_based.h
@@ -339,10 +339,7 @@ template <typename Index, typename Cluster> class InvertedIndex {
 
     template <threads::ThreadPool Pool>
     InvertedIndex(
-        Index index,
-        Cluster cluster,
-        translator_type index_local_to_global,
-        Pool threadpool
+        Index index, Cluster cluster, translator_type index_local_to_global, Pool threadpool
     )
         : index_{std::move(index)}
         , cluster_{std::move(cluster)}
@@ -358,9 +355,7 @@ template <typename Index, typename Cluster> class InvertedIndex {
     ///
     /// @brief Return the current number of threads used for search.
     ///
-    size_t get_num_threads() const {
-        return threadpool_.size();
-    }
+    size_t get_num_threads() const { return threadpool_.size(); }
 
     void set_threadpool(threads::ThreadPoolHandle threadpool) {
         threadpool_ = std::move(threadpool);
@@ -374,7 +369,9 @@ template <typename Index, typename Cluster> class InvertedIndex {
     /// @copydoc threadpool_requirements
     ///
     template <threads::ThreadPool Pool>
-    void set_threadpool(Pool threadpool) requires (!std::is_same_v<Pool, threads::ThreadPoolHandle>) {
+    void set_threadpool(Pool threadpool)
+        requires(!std::is_same_v<Pool, threads::ThreadPoolHandle>)
+    {
         set_threadpool(threads::ThreadPoolHandle(std::move(threadpool)));
     }
 
@@ -592,7 +589,11 @@ auto auto_build(
 }
 
 ///// Auto Assembling.
-template <typename DataProto, typename Distance, StorageStrategy Strategy, typename ThreadPoolProto>
+template <
+    typename DataProto,
+    typename Distance,
+    StorageStrategy Strategy,
+    typename ThreadPoolProto>
 auto assemble_from_clustering(
     const std::filesystem::path& clustering_path,
     DataProto data_proto,

--- a/include/svs/index/vamana/consolidate.h
+++ b/include/svs/index/vamana/consolidate.h
@@ -318,7 +318,7 @@ class GraphConsolidator {
             // Generate updates.
             update_buffer.prepare();
             threads::UnitRange global_ids{start, stop};
-            threads::run(
+            threads::parallel_for(
                 threadpool_,
                 threads::DynamicPartition{global_ids.eachindex(), thread_batch_size},
                 [&](const auto& local_ids, uint64_t tid) {
@@ -334,7 +334,7 @@ class GraphConsolidator {
             );
 
             // Write back results.
-            threads::run(
+            threads::parallel_for(
                 threadpool_,
                 threads::DynamicPartition{global_ids.eachindex(), thread_batch_size},
                 [&](const auto& local_ids, uint64_t /*tid*/) {

--- a/include/svs/index/vamana/dynamic_index.h
+++ b/include/svs/index/vamana/dynamic_index.h
@@ -521,7 +521,9 @@ class MutableVamanaIndex {
         size_t num_neighbors,
         QueryResultView<I> result
     ) {
-        auto temp_index = temporary_flat_index(data_, distance_, threads::ThreadPoolReferenceWrapper(threadpool_));
+        auto temp_index = temporary_flat_index(
+            data_, distance_, threads::ThreadPoolReferenceWrapper(threadpool_)
+        );
         temp_index.search(queries, num_neighbors, result, [&](size_t i) {
             return getindex(status_, i) == SlotMetadata::Valid;
         });
@@ -842,7 +844,9 @@ class MutableVamanaIndex {
     /// @copydoc threadpool_requirements
     ///
     template <threads::ThreadPool Pool>
-    void set_threadpool(Pool threadpool) requires (!std::is_same_v<Pool, threads::ThreadPoolHandle>) {
+    void set_threadpool(Pool threadpool)
+        requires(!std::is_same_v<Pool, threads::ThreadPoolHandle>)
+    {
         set_threadpool(threads::ThreadPoolHandle(std::move(threadpool)));
     }
 
@@ -1063,7 +1067,9 @@ class MutableVamanaIndex {
                 dst.set_datum(i, accessor(data_, id));
             }
         };
-        threads::parallel_for(threadpool_, threads::StaticPartition{ids_size}, threaded_function);
+        threads::parallel_for(
+            threadpool_, threads::StaticPartition{ids_size}, threaded_function
+        );
     }
 
     /// Invoke the provided callable with constant references to the contained graph, data,
@@ -1215,7 +1221,11 @@ struct VamanaStateLoader {
 } // namespace detail
 
 // Assembly
-template <typename GraphLoader, typename DataLoader, typename Distance, typename ThreadPoolProto>
+template <
+    typename GraphLoader,
+    typename DataLoader,
+    typename Distance,
+    typename ThreadPoolProto>
 auto auto_dynamic_assemble(
     const std::filesystem::path& config_path,
     GraphLoader&& graph_loader,

--- a/include/svs/index/vamana/dynamic_index.h
+++ b/include/svs/index/vamana/dynamic_index.h
@@ -839,10 +839,7 @@ class MutableVamanaIndex {
     ///
     /// @param threadpool An acceptable thread pool.
     ///
-    /// The thread pool should implement two functions:
-    /// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
-    /// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
-    /// and ``n`` represents the number of partitions that need to be executed.
+    /// @copydoc threadpool_requirements
     ///
     template <threads::ThreadPool Pool>
     void set_threadpool(Pool threadpool) requires (!std::is_same_v<Pool, threads::ThreadPoolHandle>) {

--- a/include/svs/index/vamana/extensions.h
+++ b/include/svs/index/vamana/extensions.h
@@ -559,7 +559,9 @@ void svs_invoke(
             return;
         }
         // Perform search - results will be queued in the search buffer.
-        single_search(dataset, search_buffer, distance, queries.get_datum(i), search, cancel);
+        single_search(
+            dataset, search_buffer, distance, queries.get_datum(i), search, cancel
+        );
 
         // Copy back results.
         for (size_t j = 0; j < num_neighbors; ++j) {

--- a/include/svs/index/vamana/index.h
+++ b/include/svs/index/vamana/index.h
@@ -297,7 +297,7 @@ class VamanaIndex {
     // Base distance type.
     distance_type distance_;
     // Thread-pool for batch queries.
-    threads::NativeThreadPool threadpool_;
+    threads::ThreadPoolHandle threadpool_;
     // Search Parameters (protected for multiple readers and writers).
     lib::ReadWriteProtected<VamanaSearchParameters> default_search_parameters_{};
     // Construction parameters
@@ -328,7 +328,10 @@ class VamanaIndex {
     /// @param entry_point The entry-point into the graph to begin searches.
     /// @param distance_function The distance function used to compare queries and
     ///     elements of the dataset.
-    /// @param threadpool The threadpool to use to conduct searches.
+    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable threadpool
+    ///     instance or an integer specifying the number of threads to use. In the latter case, a new
+    ///     default thread pool will be constructed using ``threadpool_proto`` as the number of
+    ///     threads to create.
     ///
     /// This is a lower-level function that is meant to take a collection of
     /// instantiated components and assemble the final index. For a more "hands-free"
@@ -341,28 +344,24 @@ class VamanaIndex {
     ///
     /// @sa auto_assemble
     ///
+    /// The thread pool should implement two functions:
+    /// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
+    /// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
+    /// and ``n`` represents the number of partitions that need to be executed.
+    ///
+    template <typename ThreadPoolProto>
     VamanaIndex(
         Graph graph,
         Data data,
         Idx entry_point,
         Dist distance_function,
-        threads::NativeThreadPool threadpool
+        ThreadPoolProto threadpool_proto
     )
         : graph_{std::move(graph)}
         , data_{std::move(data)}
         , entry_point_{entry_point}
         , distance_{std::move(distance_function)}
-        , threadpool_{std::move(threadpool)}
-        , default_search_parameters_{construct_default_search_parameters(data_)} {}
-
-    VamanaIndex(
-        Graph graph, Data data, Idx entry_point, Dist distance_function, size_t num_threads
-    )
-        : graph_{std::move(graph)}
-        , data_{std::move(data)}
-        , entry_point_{entry_point}
-        , distance_{std::move(distance_function)}
-        , threadpool_{num_threads}
+        , threadpool_{threads::as_threadpool(std::move(threadpool_proto))}
         , default_search_parameters_{construct_default_search_parameters(data_)} {}
 
     ///
@@ -375,7 +374,7 @@ class VamanaIndex {
     /// @param entry_point The entry-point into the graph to begin searches.
     /// @param distance_function The distance function used to compare queries and
     ///     elements of the dataset.
-    /// @param threadpool The threadpool to use to conduct searches.
+    /// @param threadpool The acceptable threadpool to use to conduct searches.
     ///
     /// This is a lower-level function that is meant to take a dataset and construct
     /// the graph-based index over the dataset. For a more "hands-free" approach, see
@@ -388,13 +387,14 @@ class VamanaIndex {
     ///
     /// @sa auto_build
     ///
+    template <threads::ThreadPool Pool>
     VamanaIndex(
         const VamanaBuildParameters& parameters,
         Graph graph,
         Data data,
         Idx entry_point,
         Dist distance_function,
-        threads::NativeThreadPool threadpool
+        Pool threadpool
     )
         : VamanaIndex{
               std::move(graph),
@@ -543,7 +543,7 @@ class VamanaIndex {
         const search_parameters_type& search_parameters,
         const lib::DefaultPredicate& cancel = lib::Returns(lib::Const<false>())
     ) {
-        threads::run(
+        threads::parallel_for(
             threadpool_,
             threads::StaticPartition{queries.size()},
             [&](const auto is, uint64_t SVS_UNUSED(tid)) {
@@ -647,13 +647,10 @@ class VamanaIndex {
                 dst.set_datum(i, accessor(data_, id));
             }
         };
-        threads::run(threadpool_, threads::StaticPartition{ids_size}, threaded_function);
+        threads::parallel_for(threadpool_, threads::StaticPartition{ids_size}, threaded_function);
     }
 
     ///// Threading Interface
-
-    /// Return whether this implementation can dynamically change the number of threads.
-    static bool can_change_threads() { return true; }
 
     ///
     /// @brief Return the current number of threads used for search.
@@ -661,27 +658,29 @@ class VamanaIndex {
     /// @sa set_num_threads
     size_t get_num_threads() const { return threadpool_.size(); }
 
-    ///
-    /// @brief Set the number of threads used for search.
-    ///
-    /// @param num_threads The new number of threads to use.
-    ///
-    /// Implementation note: The number of threads cannot be zero. If zero is passed to
-    /// this method, it will be silently changed to 1.
-    ///
-    /// @sa get_num_threads
-    ///
-    void set_num_threads(size_t num_threads) {
-        num_threads = std::max(num_threads, size_t(1));
-        threadpool_.resize(num_threads);
+    void set_threadpool(threads::ThreadPoolHandle threadpool) {
+        threadpool_ = std::move(threadpool);
     }
 
     ///
-    /// @brief Obtain the underlying threadpool.
+    /// @brief Destroy the original thread pool and set to the provided one.
     ///
-    /// N.B.: Jobs may be run on the thread pool but it may not be resized safely.
+    /// @param threadpool An acceptable thread pool.
     ///
-    threads::NativeThreadPool& borrow_threadpool() { return threadpool_; }
+    /// The thread pool should implement two functions:
+    /// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
+    /// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
+    /// and ``n`` represents the number of partitions that need to be executed.
+    ///
+    template <threads::ThreadPool Pool>
+    void set_threadpool(Pool threadpool) requires (!std::is_same_v<Pool, threads::ThreadPoolHandle>) {
+        set_threadpool(threads::ThreadPoolHandle(std::move(threadpool)));
+    }
+
+    ///
+    /// @brief Return the current thread pool handle.
+    ///
+    threads::ThreadPoolHandle& get_threadpool_handle() { return threadpool_; }
 
     ///// Search Parameter Setting
 
@@ -864,20 +863,28 @@ class VamanaIndex {
 /// @param data_proto A dispatch loadable class yielding a dataset.
 /// @param distance The distance **functor** to use to compare queries with elements of
 ///     the dataset.
-/// @param threadpool_proto Precursor for the thread pool to use. Can either be a
-///     threadpool instance of an integer specifying the number of threads to use.
+/// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable threadpool
+///     instance or an integer specifying the number of threads to use. In the latter case, a new
+///     default thread pool will be constructed using ``threadpool_proto`` as the number of
+///     threads to create.
 /// @param graph_allocator The allocator to use for the graph data structure.
+///
+/// The thread pool should implement two functions:
+/// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
+/// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. 
+///    Here, ``f(i)`` represents a task on the ``i^th`` partition, and ``n`` represents the number of partitions
+///    that need to be executed.
 ///
 template <
     typename DataProto,
     typename Distance,
-    typename ThreadpoolProto,
+    typename ThreadPoolProto,
     typename Allocator = HugepageAllocator<uint32_t>>
 auto auto_build(
     const VamanaBuildParameters& parameters,
     DataProto data_proto,
     Distance distance,
-    ThreadpoolProto threadpool_proto,
+    ThreadPoolProto threadpool_proto,
     const Allocator& graph_allocator = {}
 ) {
     auto threadpool = threads::as_threadpool(std::move(threadpool_proto));
@@ -904,14 +911,19 @@ auto auto_build(
 /// @param data_proto A dispatch loadable class yielding a dataset.
 /// @param distance The distance **functor** to use to compare queries with elements of
 ///        the dataset.
-/// @param threadpool_proto Precursor for the thread pool to use. Can either be a
-///        threadpool instance of an integer specifying the number of threads to use.
+/// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable
+///        threadpool instance or an integer specifying the number of threads to use.
 ///
 /// This method provides much of the heavy lifting for instantiating a Vamana index from
 /// a collection of files on disk (or perhaps a mix-and-match of existing data in-memory
 /// and on disk).
 ///
 /// Refer to the examples for use of this interface.
+///
+/// The thread pool should implement two functions:
+/// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
+/// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
+/// and ``n`` represents the number of partitions that need to be executed.
 ///
 template <
     typename GraphProto,
@@ -925,7 +937,7 @@ auto auto_assemble(
     Distance distance,
     ThreadPoolProto threadpool_proto
 ) {
-    auto threadpool = threads::as_threadpool(threadpool_proto);
+    auto threadpool = threads::as_threadpool(std::move(threadpool_proto));
     auto data = svs::detail::dispatch_load(std::move(data_proto), threadpool);
     auto graph = svs::detail::dispatch_load(std::move(graph_loader), threadpool);
 

--- a/include/svs/index/vamana/index.h
+++ b/include/svs/index/vamana/index.h
@@ -328,10 +328,11 @@ class VamanaIndex {
     /// @param entry_point The entry-point into the graph to begin searches.
     /// @param distance_function The distance function used to compare queries and
     ///     elements of the dataset.
-    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable thread pool
-    ///     instance or an integer specifying the number of threads to use. In the latter case, a new
-    ///     default thread pool will be constructed using ``threadpool_proto`` as the number of
-    ///     threads to create.
+    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an
+    /// acceptable thread pool
+    ///     instance or an integer specifying the number of threads to use. In the latter
+    ///     case, a new default thread pool will be constructed using ``threadpool_proto``
+    ///     as the number of threads to create.
     ///
     /// This is a lower-level function that is meant to take a collection of
     /// instantiated components and assemble the final index. For a more "hands-free"
@@ -512,9 +513,11 @@ class VamanaIndex {
     ///     ``num_neighbors`` is computed from the number of columns in ``result``.
     /// @param queries A dense collection of queries in R^n.
     /// @param search_parameters search parameters to use for the search.
-    /// @param cancel A predicate called during the search to determine if the search should be cancelled.
-    //      Return ``true`` if the search should be cancelled. This functor must implement ``bool operator()()``.
-    //      Note: This predicate should be thread-safe as it can be called concurrently by different threads during the search.
+    /// @param cancel A predicate called during the search to determine if the search should
+    /// be cancelled.
+    //      Return ``true`` if the search should be cancelled. This functor must implement
+    //      ``bool operator()()``. Note: This predicate should be thread-safe as it can be
+    //      called concurrently by different threads during the search.
     ///
     /// Perform a multi-threaded graph search over the index, overwriting the contents
     /// of ``result`` with the results of search.
@@ -644,7 +647,9 @@ class VamanaIndex {
                 dst.set_datum(i, accessor(data_, id));
             }
         };
-        threads::parallel_for(threadpool_, threads::StaticPartition{ids_size}, threaded_function);
+        threads::parallel_for(
+            threadpool_, threads::StaticPartition{ids_size}, threaded_function
+        );
     }
 
     ///// Threading Interface
@@ -667,7 +672,9 @@ class VamanaIndex {
     /// @copydoc threadpool_requirements
     ///
     template <threads::ThreadPool Pool>
-    void set_threadpool(Pool threadpool) requires (!std::is_same_v<Pool, threads::ThreadPoolHandle>) {
+    void set_threadpool(Pool threadpool)
+        requires(!std::is_same_v<Pool, threads::ThreadPoolHandle>)
+    {
         set_threadpool(threads::ThreadPoolHandle(std::move(threadpool)));
     }
 
@@ -857,10 +864,11 @@ class VamanaIndex {
 /// @param data_proto A dispatch loadable class yielding a dataset.
 /// @param distance The distance **functor** to use to compare queries with elements of
 ///     the dataset.
-/// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable thread pool
-///     instance or an integer specifying the number of threads to use. In the latter case, a new
-///     default thread pool will be constructed using ``threadpool_proto`` as the number of
-///     threads to create.
+/// @param threadpool_proto Precursor for the thread pool to use. Can either be an
+/// acceptable thread pool
+///     instance or an integer specifying the number of threads to use. In the latter case,
+///     a new default thread pool will be constructed using ``threadpool_proto`` as the
+///     number of threads to create.
 /// @param graph_allocator The allocator to use for the graph data structure.
 ///
 /// @copydoc threadpool_requirements
@@ -901,7 +909,8 @@ auto auto_build(
 /// @param data_proto A dispatch loadable class yielding a dataset.
 /// @param distance The distance **functor** to use to compare queries with elements of
 ///        the dataset.
-/// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable
+/// @param threadpool_proto Precursor for the thread pool to use. Can either be an
+/// acceptable
 ///        thread pool instance or an integer specifying the number of threads to use.
 ///
 /// This method provides much of the heavy lifting for instantiating a Vamana index from

--- a/include/svs/index/vamana/index.h
+++ b/include/svs/index/vamana/index.h
@@ -328,7 +328,7 @@ class VamanaIndex {
     /// @param entry_point The entry-point into the graph to begin searches.
     /// @param distance_function The distance function used to compare queries and
     ///     elements of the dataset.
-    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable threadpool
+    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable thread pool
     ///     instance or an integer specifying the number of threads to use. In the latter case, a new
     ///     default thread pool will be constructed using ``threadpool_proto`` as the number of
     ///     threads to create.
@@ -342,12 +342,9 @@ class VamanaIndex {
     /// * `graph.n_nodes() == data.size()`: Graph and data should have the same number
     /// of entries.
     ///
-    /// @sa auto_assemble
+    /// @copydoc threadpool_requirements
     ///
-    /// The thread pool should implement two functions:
-    /// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
-    /// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
-    /// and ``n`` represents the number of partitions that need to be executed.
+    /// @sa auto_assemble
     ///
     template <typename ThreadPoolProto>
     VamanaIndex(
@@ -667,10 +664,7 @@ class VamanaIndex {
     ///
     /// @param threadpool An acceptable thread pool.
     ///
-    /// The thread pool should implement two functions:
-    /// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
-    /// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
-    /// and ``n`` represents the number of partitions that need to be executed.
+    /// @copydoc threadpool_requirements
     ///
     template <threads::ThreadPool Pool>
     void set_threadpool(Pool threadpool) requires (!std::is_same_v<Pool, threads::ThreadPoolHandle>) {
@@ -863,17 +857,13 @@ class VamanaIndex {
 /// @param data_proto A dispatch loadable class yielding a dataset.
 /// @param distance The distance **functor** to use to compare queries with elements of
 ///     the dataset.
-/// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable threadpool
+/// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable thread pool
 ///     instance or an integer specifying the number of threads to use. In the latter case, a new
 ///     default thread pool will be constructed using ``threadpool_proto`` as the number of
 ///     threads to create.
 /// @param graph_allocator The allocator to use for the graph data structure.
 ///
-/// The thread pool should implement two functions:
-/// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
-/// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. 
-///    Here, ``f(i)`` represents a task on the ``i^th`` partition, and ``n`` represents the number of partitions
-///    that need to be executed.
+/// @copydoc threadpool_requirements
 ///
 template <
     typename DataProto,
@@ -912,7 +902,7 @@ auto auto_build(
 /// @param distance The distance **functor** to use to compare queries with elements of
 ///        the dataset.
 /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable
-///        threadpool instance or an integer specifying the number of threads to use.
+///        thread pool instance or an integer specifying the number of threads to use.
 ///
 /// This method provides much of the heavy lifting for instantiating a Vamana index from
 /// a collection of files on disk (or perhaps a mix-and-match of existing data in-memory
@@ -920,10 +910,7 @@ auto auto_build(
 ///
 /// Refer to the examples for use of this interface.
 ///
-/// The thread pool should implement two functions:
-/// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
-/// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
-/// and ``n`` represents the number of partitions that need to be executed.
+/// @copydoc threadpool_requirements
 ///
 template <
     typename GraphProto,

--- a/include/svs/lib/threads.h
+++ b/include/svs/lib/threads.h
@@ -32,8 +32,8 @@ namespace svs::threads {
 /// This function returns a default generic threadpool. If more specialized behavior is
 /// desired, manually construct the necessary thread pool.
 ///
-inline NativeThreadPool as_threadpool(size_t num_threads) {
-    return NativeThreadPool(num_threads);
+inline DefaultThreadPool as_threadpool(size_t num_threads) {
+    return DefaultThreadPool(num_threads);
 }
 
 ///
@@ -41,7 +41,7 @@ inline NativeThreadPool as_threadpool(size_t num_threads) {
 ///
 /// @param threadpool The thread pool to forward.
 ///
-template <threads::ThreadPool Pool> Pool&& as_threadpool(Pool&& threadpool) {
+template <ThreadPool Pool> Pool&& as_threadpool(Pool&& threadpool) {
     return std::forward<Pool>(threadpool);
 }
 

--- a/include/svs/lib/threads/threadpool.h
+++ b/include/svs/lib/threads/threadpool.h
@@ -24,6 +24,7 @@
 #include <mutex>
 #include <sstream>
 #include <vector>
+#include <queue>
 
 #include "svs/lib/numa.h"
 #include "svs/lib/threads/thread.h"
@@ -37,7 +38,7 @@ namespace threads {
 
 // clang-format off
 template <typename Pool>
-concept ThreadPool = requires(Pool& pool, const Pool& const_pool, FunctionRef f) {
+concept ThreadPool = requires(Pool& pool, const Pool& const_pool, std::function<void(size_t)> f, size_t n) {
     ///
     /// Return the number of threads in the thread pool.
     ///
@@ -46,29 +47,20 @@ concept ThreadPool = requires(Pool& pool, const Pool& const_pool, FunctionRef f)
     ///
     /// Run the fundamental function on each thread.
     ///
-    pool.run(f);
-};
+    pool.parallel_for(std::move(f), n);
 
-template <typename Pool>
-concept ResizeableThreadPool = requires(Pool& pool, size_t sz) {
-    requires(ThreadPool<Pool>);
-
-    ///
-    /// Change the number of threads in the pool.
-    ///
-    pool.resize(sz);
 };
 // clang-format on
 
-template <ThreadPool Pool, typename F> void run(Pool& pool, F&& f) {
-    auto f_wrapped = thunks::wrap(ThreadCount{pool.size()}, f);
-    pool.run(FunctionRef(f_wrapped));
+template <ThreadPool Pool, typename F> void parallel_for(Pool& pool, F&& f) {
+    pool.parallel_for(thunks::wrap(ThreadCount{pool.size()}, f), pool.size()); // Current partitioning methods will create n partitions where n equals to the number of threads.
+                                                                               // Delegate the wrapped function to threadpool
 }
 
-template <ThreadPool Pool, typename T, typename F> void run(Pool& pool, T&& arg, F&& f) {
+template <ThreadPool Pool, typename T, typename F> void parallel_for(Pool& pool, T&& arg, F&& f) {
     if (!arg.empty()) {
-        auto f_wrapped = thunks::wrap(ThreadCount{pool.size()}, f, std::forward<T>(arg));
-        pool.run(FunctionRef(f_wrapped));
+        pool.parallel_for(thunks::wrap(ThreadCount{pool.size()}, f, std::forward<T>(arg)), pool.size()); // Current partitioning methods will create n partitions where n equals to the number of threads.
+                                                                                                         // Delegate the wrapped function to threadpool
     }
 }
 
@@ -82,8 +74,14 @@ template <ThreadPool Pool, typename T, typename F> void run(Pool& pool, T&& arg,
 class SequentialThreadPool {
   public:
     SequentialThreadPool() = default;
+
     static constexpr size_t size() { return 1; }
-    static void run(FunctionRef f) { f(0); }
+
+    static void parallel_for(std::function<void(size_t)> f, size_t n) { 
+        for(size_t i = 0; i < n; ++i) {
+            f(i);
+        }
+    }
 };
 static_assert(ThreadPool<SequentialThreadPool>);
 
@@ -146,6 +144,7 @@ template <typename Builder> class NativeThreadPoolBase {
 
     size_t size() const { return threads_.size() + 1; }
 
+    // Support resize
     void resize(size_t new_size) {
         new_size = std::max(new_size, size_t{1});
         std::lock_guard lock{*use_mutex_};
@@ -159,10 +158,12 @@ template <typename Builder> class NativeThreadPoolBase {
         }
     }
 
-    void run(FunctionRef f) {
+    // TODO: This assignment underutilizes the main thread.
+    //       It's okay for now as current partitioning methods set n equals to the number of threads
+    void parallel_for(std::function<void(size_t)> f, size_t n) {
         std::lock_guard lock{*use_mutex_};
-        for (size_t i = 0; i < threads_.size(); ++i) {
-            threads_[i].assign({f, i + 1});
+        for (size_t i = 0; i < n - 1; ++i) {
+            threads_[i % (threads_.size())].assign({&f, i + 1});
         }
         // Run on the main function.
         try {
@@ -209,7 +210,7 @@ template <typename Builder> class NativeThreadPoolBase {
 
 using NativeThreadPool = NativeThreadPoolBase<DefaultBuilder>;
 // Ensure that we satisfy the requirements for a threadpool.
-static_assert(ResizeableThreadPool<NativeThreadPool>);
+static_assert(ThreadPool<NativeThreadPool>);
 
 SVS_VALIDATE_BOOL_ENV(SVS_ENABLE_NUMA);
 #if SVS_ENABLE_NUMA
@@ -230,10 +231,264 @@ auto create_on_nodes(InterNUMAThreadPool& threadpool, F&& f)
     using RetType = std::result_of_t<F(size_t)>;
     return numa::NumaLocal<RetType>(threadpool.size(), [&](auto& slots) {
         assert(slots.size() == threadpool.size());
-        threads::run(threadpool, [&](uint64_t tid) { slots[tid] = f(tid); });
+        threads::parallel_for(threadpool, [&](uint64_t tid) { slots[tid] = f(tid); });
     });
 }
 #endif
+
+/////
+///// A handy refernce wrapper for situations where we only want to share a thread pool
+/////
+template <ThreadPool Pool>
+class ThreadPoolReferenceWrapper {
+
+  public:
+
+    ThreadPoolReferenceWrapper(Pool& threadpool): threadpool_{threadpool} {
+    }
+
+    size_t size() const {
+        return threadpool_.size();
+    }
+
+    void parallel_for(std::function<void(size_t)> f, size_t n) {
+        threadpool_.parallel_for(std::move(f), n);
+    }
+
+  private:
+
+    Pool& threadpool_;
+};
+
+/////
+///// A thread pool implementation using std::async
+/////
+class CppAsyncThreadPool {
+
+  public:
+      explicit CppAsyncThreadPool(size_t max_async_tasks): _max_async_tasks{max_async_tasks} {
+      }
+
+      void parallel_for(std::function<void(size_t)> f, size_t n) {
+        std::vector<std::future<void>> futures;
+        futures.reserve(n);
+        for(size_t i = 0; i < n; ++i) {
+            futures.emplace_back(
+                std::async(std::launch::async, [&f](size_t i){ f(i); }, i)
+            );
+            if(futures.size() == _max_async_tasks) {
+              // wait until all async tasks are finished
+              std::for_each(futures.begin(), futures.end(), [](std::future<void>& fu) { fu.get(); });
+              futures.clear();
+            }
+        }
+
+        // wait until all async tasks are finished
+        std::for_each(futures.begin(), futures.end(), [](std::future<void>& fu) { fu.get(); });
+      }
+
+      size_t size() const {
+          return _max_async_tasks;
+      }
+
+      // support resize
+      void resize(size_t max_async_tasks) {
+          _max_async_tasks = max_async_tasks;
+      }
+
+
+  private:
+
+      size_t _max_async_tasks{1};
+};
+static_assert(ThreadPool<CppAsyncThreadPool>);
+
+/////
+///// A thread pool implementation using a centrialized task queue
+/////
+class QueueThreadPool {
+
+  public:
+      explicit QueueThreadPool(size_t num_threads) {
+          threads_.reserve(num_threads);
+          for(size_t i = 0; i < num_threads; ++i) {
+              threads_.emplace_back([this]() {
+                  while(!stop_) {
+                      std::function<void()> task;
+                      {
+                          std::unique_lock lock(mtx_);
+                          while(queue_.empty() && !stop_) {
+                              cv_.wait(lock);
+                          }
+                          if(!queue_.empty()) {
+                              task = queue_.front();
+                              queue_.pop();
+                          }
+                      }
+
+                      if(task) {
+                          task();
+                      }
+                  }
+              });
+          }
+      }
+
+      QueueThreadPool(QueueThreadPool&&) = delete;
+      QueueThreadPool(const QueueThreadPool&) = delete;
+      QueueThreadPool& operator=(QueueThreadPool&&) = delete;
+      QueueThreadPool& operator=(const QueueThreadPool&) = delete;
+
+      ~QueueThreadPool() {
+          shutdown();
+          for(auto& t: threads_) {
+              t.join();
+          }
+      }
+
+      template <typename C>
+      std::future<void> insert(C&& task) {
+          std::promise<void> prom;
+          std::future<void> fu = prom.get_future();
+          {
+              std::scoped_lock lock(mtx_);
+              queue_.push([moc=MoC{std::move(prom)}, task=std::forward<C>(task)]() mutable {
+                  task();
+                  moc.obj.set_value();
+              });
+          }
+          cv_.notify_one();
+          return fu;
+      }
+
+      size_t size() const {
+          return threads_.size();
+      }
+
+      void shutdown() {
+          std::scoped_lock lock(mtx_);
+          stop_ = true;
+          cv_.notify_all();
+      }
+
+  private:
+
+      std::vector<std::thread> threads_;
+      std::mutex mtx_;
+      std::condition_variable cv_;
+
+      bool stop_{false};
+      std::queue<std::function<void()>> queue_;
+};
+
+/////
+///// The wrapper for QueueThreadPool to work on SVS
+/////
+class QueueThreadPoolWrapper {
+
+  public:
+
+      QueueThreadPoolWrapper(size_t num_threads): threadpool_{std::make_unique<QueueThreadPool>(num_threads)} {
+      }
+
+      void parallel_for(std::function<void(size_t)> f, size_t n) {
+        std::vector<std::future<void>> futures;
+        futures.reserve(n);
+        for(size_t i = 0; i < n; ++i) {
+            futures.emplace_back(threadpool_->insert([&f, i]() {
+                f(i);
+            }));
+        }
+
+        // wait until all tasks are finished
+        for(auto& fu: futures) {
+            fu.get();
+        }
+      }
+
+      size_t size() const {
+          return threadpool_->size();
+      }
+
+  private:
+
+      std::unique_ptr<QueueThreadPool> threadpool_;
+};
+static_assert(ThreadPool<QueueThreadPoolWrapper>);
+
+/////
+///// Type erasure thread pool implementation
+/////
+
+class ThreadPoolInterface {
+
+    public:
+
+      virtual ~ThreadPoolInterface() = default;
+      virtual size_t size() const = 0;
+      virtual void parallel_for(std::function<void(size_t)>, size_t) = 0;
+};
+
+template <ThreadPool Impl>
+class ThreadPoolImpl: public ThreadPoolInterface {
+
+  public:
+
+    explicit ThreadPoolImpl(Impl&& impl)
+        : ThreadPoolInterface{}
+        , impl_{std::move(impl)} {}
+
+    size_t size() const override {
+        return impl_.size();
+    }
+
+    void parallel_for(std::function<void(size_t)> f, size_t n) override {
+        impl_.parallel_for(std::move(f), n);
+    }
+
+    Impl& get() {
+        return impl_;
+    }
+
+  private:
+
+    Impl impl_;
+};
+
+class ThreadPoolHandle {
+
+  public:
+
+    template <ThreadPool Impl>
+    explicit ThreadPoolHandle(Impl&& impl) requires (!std::is_same_v<Impl, ThreadPoolHandle>) && std::is_rvalue_reference_v<Impl&&> : impl_{std::make_unique<ThreadPoolImpl<Impl>>(std::move(impl))} {
+    }
+
+    size_t size() const {
+        return impl_->size();
+    }
+
+    void parallel_for(std::function<void(size_t)> f, size_t n) {
+        impl_->parallel_for(std::move(f), n);
+    }
+
+    template <ThreadPool Impl>
+    auto& get() {
+        ThreadPoolImpl<Impl>* result = dynamic_cast<ThreadPoolImpl<Impl>*>(impl_.get());
+        if(result != nullptr) {
+            return result->get();
+        }
+        else {
+            throw ANNEXCEPTION("Failed to cast to the provided threadpool type");
+        }
+    }
+
+  private:
+
+    std::unique_ptr<ThreadPoolInterface> impl_;
+};
+
+// SVS default threadpool
+using DefaultThreadPool = NativeThreadPool;
 
 } // namespace threads
 } // namespace svs

--- a/include/svs/lib/threads/threadpool.h
+++ b/include/svs/lib/threads/threadpool.h
@@ -36,6 +36,17 @@
 namespace svs {
 namespace threads {
 
+///
+/// @class threadpool_requirements
+///
+/// ThreadPool
+/// ===========
+/// An acceptable thread pool should implement two methods:
+/// * ``size_t size()``. This method should return the number of threads used in the thread pool.
+/// * ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
+/// and ``n`` represents the number of partitions that need to be executed.
+///
+
 // clang-format off
 template <typename Pool>
 concept ThreadPool = requires(Pool& pool, const Pool& const_pool, std::function<void(size_t)> f, size_t n) {

--- a/include/svs/lib/threads/thunks.h
+++ b/include/svs/lib/threads/thunks.h
@@ -30,10 +30,11 @@ namespace svs {
 namespace threads {
 
 // Move on Copy
-template <typename T>
-struct MoC {
-    MoC(T&& rhs): obj(std::move(rhs)) {}
-    MoC(const MoC& other): obj(std::move(other.obj)) {}
+template <typename T> struct MoC {
+    MoC(T&& rhs)
+        : obj(std::move(rhs)) {}
+    MoC(const MoC& other)
+        : obj(std::move(other.obj)) {}
     T& get() { return obj; }
     mutable T obj;
 };
@@ -91,8 +92,9 @@ template <typename F, typename I> struct Thunk<F, StaticPartition<I>> {
 // Dynamic partition
 template <typename F, typename I> struct Thunk<F, DynamicPartition<I>> {
     static auto wrap(ThreadCount SVS_UNUSED(nthreads), F& f, DynamicPartition<I> space) {
-        auto count_ = std::make_unique<std::atomic<uint64_t>>(0); // workaround for atomic being not copyable and movable
-        return [&f, space, count=MoC(std::move(count_))](uint64_t tid) mutable {
+        auto count_ = std::make_unique<std::atomic<uint64_t>>(0
+        ); // workaround for atomic being not copyable and movable
+        return [&f, space, count = MoC(std::move(count_))](uint64_t tid) mutable {
             size_t grainsize = space.grainsize;
             size_t iterator_size = space.size();
             for (;;) {

--- a/include/svs/misc/dynamic_helper.h
+++ b/include/svs/misc/dynamic_helper.h
@@ -134,7 +134,7 @@ template <typename Idx, typename Eltype, size_t N, typename Dist> class Referenc
     ///
     /// @param data The dataset to use
     /// @param distance The distance functor to use.
-    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable threadpool
+    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable thread pool
     ///     instance or an integer specifying the number of threads to use. In the latter case, a new
     ///     default thread pool will be constructed using ``threadpool_proto`` as the number of
     ///     threads to create.
@@ -144,11 +144,7 @@ template <typename Idx, typename Eltype, size_t N, typename Dist> class Referenc
     /// @param queries The query set that will be used.
     /// @param rng_seed The seed to use for random number generator initialization.
     ///
-    ///
-    /// The thread pool should implement two functions:
-    /// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
-    /// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
-    /// and ``n`` represents the number of partitions that need to be executed.
+    /// @copydoc threadpool_requirements
     ///
     template <data::ImmutableMemoryDataset Queries, typename ThreadPoolProto>
     ReferenceDataset(

--- a/include/svs/misc/dynamic_helper.h
+++ b/include/svs/misc/dynamic_helper.h
@@ -134,10 +134,11 @@ template <typename Idx, typename Eltype, size_t N, typename Dist> class Referenc
     ///
     /// @param data The dataset to use
     /// @param distance The distance functor to use.
-    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable thread pool
-    ///     instance or an integer specifying the number of threads to use. In the latter case, a new
-    ///     default thread pool will be constructed using ``threadpool_proto`` as the number of
-    ///     threads to create.
+    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an
+    /// acceptable thread pool
+    ///     instance or an integer specifying the number of threads to use. In the latter
+    ///     case, a new default thread pool will be constructed using ``threadpool_proto``
+    ///     as the number of threads to create.
     /// @param bucket_size Target number of IDs to use per bucket.
     /// @param num_neighbors The number of neighbors to retrieve when computing the base
     ///     ground truth.
@@ -188,7 +189,9 @@ template <typename Idx, typename Eltype, size_t N, typename Dist> class Referenc
                 threads::UnitRange<Idx>(lib::narrow<Idx>(start), lib::narrow<Idx>(stop));
             auto view = data::make_const_view(data_, ids);
 
-            auto index = index::flat::temporary_flat_index(view, distance_, threads::ThreadPoolReferenceWrapper(threadpool_));
+            auto index = index::flat::temporary_flat_index(
+                view, distance_, threads::ThreadPoolReferenceWrapper(threadpool_)
+            );
             auto groundtruth =
                 svs::index::search_batch(index, queries.cview(), num_neighbors);
 

--- a/include/svs/orchestrators/dynamic_vamana.h
+++ b/include/svs/orchestrators/dynamic_vamana.h
@@ -243,7 +243,11 @@ class DynamicVamana : public manager::IndexManager<DynamicVamanaInterface> {
         ThreadPoolProto threadpool_proto
     ) {
         return make_dynamic_vamana<manager::as_typelist<QueryTypes>>(
-            parameters, std::move(data), ids, std::move(distance), threads::as_threadpool(std::move(threadpool_proto))
+            parameters,
+            std::move(data),
+            ids,
+            std::move(distance),
+            threads::as_threadpool(std::move(threadpool_proto))
         );
     }
 

--- a/include/svs/orchestrators/dynamic_vamana.h
+++ b/include/svs/orchestrators/dynamic_vamana.h
@@ -233,16 +233,17 @@ class DynamicVamana : public manager::IndexManager<DynamicVamanaInterface> {
     template <
         manager::QueryTypeDefinition QueryTypes,
         data::ImmutableMemoryDataset Data,
-        typename Distance>
+        typename Distance,
+        typename ThreadPoolProto>
     static DynamicVamana build(
         const index::vamana::VamanaBuildParameters& parameters,
         Data data,
         std::span<const size_t> ids,
         Distance distance,
-        size_t num_threads
+        ThreadPoolProto threadpool_proto
     ) {
         return make_dynamic_vamana<manager::as_typelist<QueryTypes>>(
-            parameters, std::move(data), ids, std::move(distance), num_threads
+            parameters, std::move(data), ids, std::move(distance), threads::as_threadpool(std::move(threadpool_proto))
         );
     }
 
@@ -251,13 +252,14 @@ class DynamicVamana : public manager::IndexManager<DynamicVamanaInterface> {
         manager::QueryTypeDefinition QueryTypes,
         typename GraphLoader,
         typename DataLoader,
-        typename Distance>
+        typename Distance,
+        typename ThreadPoolProto>
     static DynamicVamana assemble(
         const std::filesystem::path& config_path,
         const GraphLoader& graph_loader,
         const DataLoader& data_loader,
         const Distance& distance,
-        size_t num_threads,
+        ThreadPoolProto threadpool_proto,
         bool debug_load_from_static = false
     ) {
         return DynamicVamana(
@@ -268,7 +270,7 @@ class DynamicVamana : public manager::IndexManager<DynamicVamanaInterface> {
                 graph_loader,
                 data_loader,
                 distance,
-                num_threads,
+                threads::as_threadpool(std::move(threadpool_proto)),
                 debug_load_from_static
             )
         );

--- a/include/svs/orchestrators/exhaustive.h
+++ b/include/svs/orchestrators/exhaustive.h
@@ -87,10 +87,11 @@ class Flat : public manager::IndexManager<FlatInterface> {
     ///
     /// @param data_loader A compatible class capable of load data. See expanded notes.
     /// @param distance A distance functor to use or a ``svs::DistanceType`` enum.
-    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable thread pool
-    ///     instance or an integer specifying the number of threads to use. In the latter case, a new
-    ///     default thread pool will be constructed using ``threadpool_proto`` as the number of
-    ///     threads to create.
+    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an
+    /// acceptable thread pool
+    ///     instance or an integer specifying the number of threads to use. In the latter
+    ///     case, a new default thread pool will be constructed using ``threadpool_proto``
+    ///     as the number of threads to create.
     ///
     /// @copydoc hidden_flat_auto_assemble
     ///
@@ -101,7 +102,9 @@ class Flat : public manager::IndexManager<FlatInterface> {
         typename DataLoader,
         typename Distance,
         typename ThreadPoolProto>
-    static Flat assemble(DataLoader&& data_loader, Distance distance, ThreadPoolProto threadpool_proto) {
+    static Flat assemble(
+        DataLoader&& data_loader, Distance distance, ThreadPoolProto threadpool_proto
+    ) {
         if constexpr (std::is_same_v<std::decay_t<Distance>, DistanceType>) {
             auto dispatcher = DistanceDispatcher{distance};
             return dispatcher([&](auto distance_function) {

--- a/include/svs/orchestrators/exhaustive.h
+++ b/include/svs/orchestrators/exhaustive.h
@@ -87,18 +87,14 @@ class Flat : public manager::IndexManager<FlatInterface> {
     ///
     /// @param data_loader A compatible class capable of load data. See expanded notes.
     /// @param distance A distance functor to use or a ``svs::DistanceType`` enum.
-    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable threadpool
+    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable thread pool
     ///     instance or an integer specifying the number of threads to use. In the latter case, a new
     ///     default thread pool will be constructed using ``threadpool_proto`` as the number of
     ///     threads to create.
     ///
     /// @copydoc hidden_flat_auto_assemble
     ///
-    ///
-    /// The thread pool should implement two functions:
-    /// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
-    /// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
-    /// and ``n`` represents the number of partitions that need to be executed.
+    /// @copydoc threadpool_requirements
     ///
     template <
         manager::QueryTypeDefinition QueryTypes,

--- a/include/svs/orchestrators/inverted.h
+++ b/include/svs/orchestrators/inverted.h
@@ -111,7 +111,7 @@ class Inverted : public manager::IndexManager<InvertedInterface> {
         manager::QueryTypeDefinition QueryTypes,
         typename DataProto,
         typename Distance,
-        typename ThreadpoolProto,
+        typename ThreadPoolProto,
         index::inverted::StorageStrategy Strategy = index::inverted::SparseStrategy,
         typename CentroidPicker = svs::tag_t<index::inverted::pick_centroids_randomly>,
         typename ClusteringOp = svs::tag_t<index::inverted::no_clustering_post_op>>
@@ -119,7 +119,7 @@ class Inverted : public manager::IndexManager<InvertedInterface> {
         const index::inverted::InvertedBuildParameters& build_parameters,
         DataProto data_proto,
         Distance distance,
-        ThreadpoolProto threadpool_proto,
+        ThreadPoolProto threadpool_proto,
         Strategy strategy = {},
         CentroidPicker centroid_picker = {},
         ClusteringOp clustering_post_op = {}
@@ -144,6 +144,7 @@ class Inverted : public manager::IndexManager<InvertedInterface> {
         manager::QueryTypeDefinition QueryTypes,
         typename DataProto,
         typename Distance,
+        typename ThreadPoolProto,
         typename StorageStrategy = index::inverted::SparseStrategy>
     static Inverted assemble_from_clustering(
         const std::filesystem::path& clustering_path,
@@ -151,7 +152,7 @@ class Inverted : public manager::IndexManager<InvertedInterface> {
         Distance distance,
         const std::filesystem::path& index_config,
         const std::filesystem::path& graph,
-        size_t num_threads,
+        ThreadPoolProto threadpool_proto,
         StorageStrategy strategy = {}
     ) {
         return Inverted{
@@ -164,7 +165,7 @@ class Inverted : public manager::IndexManager<InvertedInterface> {
                 std::move(strategy),
                 index_config,
                 graph,
-                num_threads
+                std::move(threadpool_proto)
             )};
     }
 };

--- a/include/svs/orchestrators/manager.h
+++ b/include/svs/orchestrators/manager.h
@@ -90,9 +90,9 @@ template <typename IFace> class ManagerInterface : public IFace {
     virtual std::vector<svs::DataType> query_types() const = 0;
 
     // Threading interface
-    virtual bool can_change_threads() const = 0;
     virtual size_t get_num_threads() const = 0;
-    virtual void set_num_threads(size_t) = 0;
+    virtual void set_threadpool(threads::ThreadPoolHandle threadpool) = 0;
+    virtual threads::ThreadPoolHandle& get_threadpool_handle() = 0;
 
     // Delete the special member functions.
     ManagerInterface(const ManagerInterface&) = delete;
@@ -175,12 +175,14 @@ class ManagerImpl : public ManagerInterface<IFace> {
     };
 
     // Threading interface.
-    bool can_change_threads() const override {
-        return implementation_.can_change_threads();
-    }
     size_t get_num_threads() const override { return implementation_.get_num_threads(); }
-    void set_num_threads(size_t num_threads) override {
-        implementation_.set_num_threads(num_threads);
+
+    void set_threadpool(threads::ThreadPoolHandle threadpool) override {
+        implementation_.set_threadpool(std::move(threadpool));
+    }
+
+    threads::ThreadPoolHandle& get_threadpool_handle() override {
+        return implementation_.get_threadpool_handle();
     }
 
   protected:
@@ -248,25 +250,34 @@ template <typename IFace> class IndexManager {
     ///// Threading Interface
 
     ///
-    /// @brief Return whether the back-end implementation can change the number of threads.
-    ///
-    bool can_change_threads() const { return impl_->can_change_threads(); }
-
-    ///
     /// @brief Return the current number of worker threads used by this index for searches.
     ///
     size_t get_num_threads() const { return impl_->get_num_threads(); }
 
+    void set_threadpool(threads::ThreadPoolHandle threadpool) {
+        impl_->set_threadpool(std::move(threadpool));
+    }
+
     ///
-    /// @brief Set the number of threads to use for searching.
+    /// @brief Destroy the original thread pool and set to the new one.
     ///
-    /// @param num_threads The number of threads to use. If set to ``0``, will implicitly
-    ///     default to ``1``.
+    /// @param threadpool An acceptable thread pool.
     ///
-    /// Only effective if ``can_change_threads()`` returns ``true``.
+    /// The thread pool should implement two functions:
+    /// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
+    /// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
+    /// and ``n`` represents the number of partitions that need to be executed.
     ///
-    void set_num_threads(size_t num_threads) {
-        impl_->set_num_threads(std::max(size_t(1), num_threads));
+    template <threads::ThreadPool Pool>
+    void set_threadpool(Pool threadpool) requires (!std::is_same_v<threads::ThreadPoolHandle, Pool>) {
+        set_threadpool(threads::ThreadPoolHandle(std::move(threadpool)));
+    }
+
+    ///
+    /// @brief Return the current thread pool handle.
+    ///
+    threads::ThreadPoolHandle& get_threadpool_handle() {
+        return impl_->get_threadpool_handle();
     }
 
     // The implementation is `protected` instead of private because derived classes

--- a/include/svs/orchestrators/manager.h
+++ b/include/svs/orchestrators/manager.h
@@ -266,7 +266,9 @@ template <typename IFace> class IndexManager {
     /// @copydoc threadpool_requirements
     ///
     template <threads::ThreadPool Pool>
-    void set_threadpool(Pool threadpool) requires (!std::is_same_v<threads::ThreadPoolHandle, Pool>) {
+    void set_threadpool(Pool threadpool)
+        requires(!std::is_same_v<threads::ThreadPoolHandle, Pool>)
+    {
         set_threadpool(threads::ThreadPoolHandle(std::move(threadpool)));
     }
 

--- a/include/svs/orchestrators/manager.h
+++ b/include/svs/orchestrators/manager.h
@@ -263,10 +263,7 @@ template <typename IFace> class IndexManager {
     ///
     /// @param threadpool An acceptable thread pool.
     ///
-    /// The thread pool should implement two functions:
-    /// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
-    /// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
-    /// and ``n`` represents the number of partitions that need to be executed.
+    /// @copydoc threadpool_requirements
     ///
     template <threads::ThreadPool Pool>
     void set_threadpool(Pool threadpool) requires (!std::is_same_v<threads::ThreadPoolHandle, Pool>) {

--- a/include/svs/orchestrators/vamana.h
+++ b/include/svs/orchestrators/vamana.h
@@ -376,7 +376,7 @@ class Vamana : public manager::IndexManager<VamanaInterface> {
     ///     See the documentation below for details.
     /// @param distance The distance functor or ``svs::DistanceType`` enum to use for
     ///     similarity search computations.
-    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable threadpool
+    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable thread pool
     ///     instance or an integer specifying the number of threads to use. In the latter case, a new
     ///     default thread pool will be constructed using ``threadpool_proto`` as the number of
     ///     threads to create.
@@ -387,10 +387,7 @@ class Vamana : public manager::IndexManager<VamanaInterface> {
     /// * An instance of ``VectorDataLoader``.
     /// * An implementation of ``svs::data::ImmutableMemoryDataset`` (passed by value).
     ///
-    /// The thread pool should implement two functions:
-    /// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
-    /// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
-    /// and ``n`` represents the number of partitions that need to be executed.
+    /// @copydoc threadpool_requirements
     ///
     /// @sa save, build
     ///
@@ -446,7 +443,7 @@ class Vamana : public manager::IndexManager<VamanaInterface> {
     /// @param data_loader Either a data loader from disk or a dataset by value.
     ///     See detailed notes below.
     /// @param distance The distance functor to use or a ``svs::DistanceType`` enum.
-    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable threadpool
+    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable thread pool
     ///     instance or an integer specifying the number of threads to use. In the latter case, a new
     ///     default thread pool will be constructed using ``threadpool_proto`` as the number of
     ///     threads to create.
@@ -458,10 +455,7 @@ class Vamana : public manager::IndexManager<VamanaInterface> {
     /// * An instance of ``VectorDataLoader``.
     /// * An implementation of ``svs::data::ImmutableMemoryDataset`` (passed by value).
     ///
-    /// The thread pool should implement two functions:
-    /// 1) ``size_t size()`` This method should return the number of workers (threads) used in the thread pool.
-    /// 2) ``void parallel_for(std::function<void(size_t)> f, size_t n)``. This method should execute ``f``. Here, ``f(i)`` represents a task on the ``i^th`` partition,
-    /// and ``n`` represents the number of partitions that need to be executed.
+    /// @copydoc threadpool_requirements
     ///
     /// @sa assemble, save
     ///

--- a/include/svs/orchestrators/vamana.h
+++ b/include/svs/orchestrators/vamana.h
@@ -376,10 +376,11 @@ class Vamana : public manager::IndexManager<VamanaInterface> {
     ///     See the documentation below for details.
     /// @param distance The distance functor or ``svs::DistanceType`` enum to use for
     ///     similarity search computations.
-    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable thread pool
-    ///     instance or an integer specifying the number of threads to use. In the latter case, a new
-    ///     default thread pool will be constructed using ``threadpool_proto`` as the number of
-    ///     threads to create.
+    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an
+    /// acceptable thread pool
+    ///     instance or an integer specifying the number of threads to use. In the latter
+    ///     case, a new default thread pool will be constructed using ``threadpool_proto``
+    ///     as the number of threads to create.
     ///
     /// The data loader should be any object loadable via ``svs::detail::dispatch_load``
     /// returning a Vamana compatible dataset. Concrete examples include:
@@ -443,10 +444,11 @@ class Vamana : public manager::IndexManager<VamanaInterface> {
     /// @param data_loader Either a data loader from disk or a dataset by value.
     ///     See detailed notes below.
     /// @param distance The distance functor to use or a ``svs::DistanceType`` enum.
-    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an acceptable thread pool
-    ///     instance or an integer specifying the number of threads to use. In the latter case, a new
-    ///     default thread pool will be constructed using ``threadpool_proto`` as the number of
-    ///     threads to create.
+    /// @param threadpool_proto Precursor for the thread pool to use. Can either be an
+    /// acceptable thread pool
+    ///     instance or an integer specifying the number of threads to use. In the latter
+    ///     case, a new default thread pool will be constructed using ``threadpool_proto``
+    ///     as the number of threads to create.
     /// @param graph_allocator The allocator to use for the backing graph.
     ///
     /// The data loader should be any object loadable via ``svs::detail::dispatch_load``

--- a/tests/integration/cancel.cpp
+++ b/tests/integration/cancel.cpp
@@ -101,7 +101,7 @@ CATCH_TEST_CASE("Cancel", "[integration][cancel]") {
         auto groundtruth_all = test_dataset::load_groundtruth(svs::L2);
         auto groundtruth = test_dataset::get_test_set(groundtruth_all, queries_in_test_set);
         index.set_search_parameters(expected.search_parameters_);
-        index.set_num_threads(num_threads);
+        index.set_threadpool(svs::threads::DefaultThreadPool(num_threads));
         auto results = index.search(queries, expected.num_neighbors_, timeout);
         auto recall = svs::k_recall_at_n(
             groundtruth, results, expected.num_neighbors_, expected.recall_k_

--- a/tests/integration/exhaustive.cpp
+++ b/tests/integration/exhaustive.cpp
@@ -66,7 +66,11 @@ void test_predicate(Index& index, const Queries& queries) {
     }
 }
 
-template <typename Index, typename Queries, typename GroundTruth, svs::threads::ThreadPool Pool = svs::threads::DefaultThreadPool>
+template <
+    typename Index,
+    typename Queries,
+    typename GroundTruth,
+    svs::threads::ThreadPool Pool = svs::threads::DefaultThreadPool>
 void test_flat(Index& index, const Queries& queries, const GroundTruth& groundtruth) {
     CATCH_REQUIRE(index.size() == test_dataset::VECTORS_IN_DATA_SET);
     CATCH_REQUIRE(index.dimensions() == test_dataset::NUM_DIMENSIONS);
@@ -137,7 +141,9 @@ CATCH_TEST_CASE("Flat Index Search", "[integration][exhaustive][index]") {
         {
             auto threadpool = svs::threads::DefaultThreadPool(4);
             auto temp = svs::index::flat::temporary_flat_index(
-                data, svs::distance::DistanceL2(), svs::threads::ThreadPoolReferenceWrapper(threadpool)
+                data,
+                svs::distance::DistanceL2(),
+                svs::threads::ThreadPoolReferenceWrapper(threadpool)
             );
             test_flat(temp, queries, groundtruth);
         }
@@ -172,29 +178,52 @@ CATCH_TEST_CASE("Flat Index Search", "[integration][exhaustive][index]") {
     CATCH_SECTION("Flat Index With CppAyncThreadPool - IP") {
         auto groundtruth = test_dataset::groundtruth_mip();
         auto index = svs::index::flat::FlatIndex(
-            std::move(data), svs::distance::DistanceIP{}, svs::threads::CppAsyncThreadPool(2)
+            std::move(data),
+            svs::distance::DistanceIP{},
+            svs::threads::CppAsyncThreadPool(2)
         );
-        test_flat<decltype(index), decltype(queries), decltype(groundtruth), svs::threads::CppAsyncThreadPool>(index, queries, groundtruth);
-        auto& threadpool = index.get_threadpool_handle().get<svs::threads::CppAsyncThreadPool>();
+        test_flat<
+            decltype(index),
+            decltype(queries),
+            decltype(groundtruth),
+            svs::threads::CppAsyncThreadPool>(index, queries, groundtruth);
+        auto& threadpool =
+            index.get_threadpool_handle().get<svs::threads::CppAsyncThreadPool>();
         threadpool.resize(3);
         CATCH_REQUIRE(index.get_num_threads() == 3);
-        test_flat<decltype(index), decltype(queries), decltype(groundtruth), svs::threads::CppAsyncThreadPool>(index, queries, groundtruth);
+        test_flat<
+            decltype(index),
+            decltype(queries),
+            decltype(groundtruth),
+            svs::threads::CppAsyncThreadPool>(index, queries, groundtruth);
     }
 
     CATCH_SECTION("Flat Index With QueueThreadPoolWrapper - Cosine") {
         auto groundtruth = test_dataset::groundtruth_cosine();
         auto index = svs::index::flat::FlatIndex(
-            std::move(data), svs::distance::DistanceCosineSimilarity{}, svs::threads::QueueThreadPoolWrapper(2)
+            std::move(data),
+            svs::distance::DistanceCosineSimilarity{},
+            svs::threads::QueueThreadPoolWrapper(2)
         );
-        test_flat<decltype(index), decltype(queries), decltype(groundtruth), svs::threads::QueueThreadPoolWrapper>(index, queries, groundtruth);
+        test_flat<
+            decltype(index),
+            decltype(queries),
+            decltype(groundtruth),
+            svs::threads::QueueThreadPoolWrapper>(index, queries, groundtruth);
     }
 
     CATCH_SECTION("Flat Index With Different Thread Pools - Cosine") {
         auto groundtruth = test_dataset::groundtruth_cosine();
         auto index = svs::index::flat::FlatIndex(
-            std::move(data), svs::distance::DistanceCosineSimilarity{}, svs::threads::QueueThreadPoolWrapper(2)
+            std::move(data),
+            svs::distance::DistanceCosineSimilarity{},
+            svs::threads::QueueThreadPoolWrapper(2)
         );
-        test_flat<decltype(index), decltype(queries), decltype(groundtruth), svs::threads::CppAsyncThreadPool>(index, queries, groundtruth);
+        test_flat<
+            decltype(index),
+            decltype(queries),
+            decltype(groundtruth),
+            svs::threads::CppAsyncThreadPool>(index, queries, groundtruth);
         test_flat(index, queries, groundtruth);
     }
 }
@@ -264,30 +293,71 @@ CATCH_TEST_CASE("Flat Orchestrator Search", "[integration][exhaustive][orchestra
 
     CATCH_SECTION("Cosine With Different Thread Pools From File") {
         svs::Flat index = svs::Flat::assemble<float>(
-            svs::VectorDataLoader<float>(test_dataset::data_svs_file()), svs::Cosine, svs::threads::CppAsyncThreadPool(2)
+            svs::VectorDataLoader<float>(test_dataset::data_svs_file()),
+            svs::Cosine,
+            svs::threads::CppAsyncThreadPool(2)
         );
         CATCH_REQUIRE(index.get_num_threads() == 2);
 
-        auto& threadpool = index.get_threadpool_handle().get<svs::threads::CppAsyncThreadPool>();
+        auto& threadpool =
+            index.get_threadpool_handle().get<svs::threads::CppAsyncThreadPool>();
         threadpool.resize(3);
         CATCH_REQUIRE(index.get_num_threads() == 3);
-        test_flat<decltype(index), decltype(queries), decltype(test_dataset::groundtruth_cosine()), svs::threads::CppAsyncThreadPool>(index, queries, test_dataset::groundtruth_cosine());
+        test_flat<
+            decltype(index),
+            decltype(queries),
+            decltype(test_dataset::groundtruth_cosine()),
+            svs::threads::CppAsyncThreadPool>(
+            index, queries, test_dataset::groundtruth_cosine()
+        );
 
         index.set_threadpool(svs::threads::DefaultThreadPool(3));
-        test_flat<decltype(index), decltype(queries), decltype(test_dataset::groundtruth_cosine()), svs::threads::DefaultThreadPool>(index, queries, test_dataset::groundtruth_cosine());
+        test_flat<
+            decltype(index),
+            decltype(queries),
+            decltype(test_dataset::groundtruth_cosine()),
+            svs::threads::DefaultThreadPool>(
+            index, queries, test_dataset::groundtruth_cosine()
+        );
 
-        test_flat<decltype(index), decltype(queries), decltype(test_dataset::groundtruth_cosine()), svs::threads::QueueThreadPoolWrapper>(index, queries, test_dataset::groundtruth_cosine());
+        test_flat<
+            decltype(index),
+            decltype(queries),
+            decltype(test_dataset::groundtruth_cosine()),
+            svs::threads::QueueThreadPoolWrapper>(
+            index, queries, test_dataset::groundtruth_cosine()
+        );
     }
 
     CATCH_SECTION("Cosine With Different Thread Pools From Data") {
-        svs::Flat index = svs::Flat::assemble<float>(std::move(data), svs::Cosine, svs::threads::QueueThreadPoolWrapper(3));
+        svs::Flat index = svs::Flat::assemble<float>(
+            std::move(data), svs::Cosine, svs::threads::QueueThreadPoolWrapper(3)
+        );
         CATCH_REQUIRE(index.get_num_threads() == 3);
-        test_flat<decltype(index), decltype(queries), decltype(test_dataset::groundtruth_cosine()), svs::threads::QueueThreadPoolWrapper>(index, queries, test_dataset::groundtruth_cosine());
+        test_flat<
+            decltype(index),
+            decltype(queries),
+            decltype(test_dataset::groundtruth_cosine()),
+            svs::threads::QueueThreadPoolWrapper>(
+            index, queries, test_dataset::groundtruth_cosine()
+        );
 
         index.set_threadpool(svs::threads::CppAsyncThreadPool(2));
         CATCH_REQUIRE(index.get_num_threads() == 2);
-        test_flat<decltype(index), decltype(queries), decltype(test_dataset::groundtruth_cosine()), svs::threads::CppAsyncThreadPool>(index, queries, test_dataset::groundtruth_cosine());
+        test_flat<
+            decltype(index),
+            decltype(queries),
+            decltype(test_dataset::groundtruth_cosine()),
+            svs::threads::CppAsyncThreadPool>(
+            index, queries, test_dataset::groundtruth_cosine()
+        );
 
-        test_flat<decltype(index), decltype(queries), decltype(test_dataset::groundtruth_cosine()), svs::threads::DefaultThreadPool>(index, queries, test_dataset::groundtruth_cosine());
+        test_flat<
+            decltype(index),
+            decltype(queries),
+            decltype(test_dataset::groundtruth_cosine()),
+            svs::threads::DefaultThreadPool>(
+            index, queries, test_dataset::groundtruth_cosine()
+        );
     }
 }

--- a/tests/integration/exhaustive.cpp
+++ b/tests/integration/exhaustive.cpp
@@ -66,7 +66,7 @@ void test_predicate(Index& index, const Queries& queries) {
     }
 }
 
-template <typename Index, typename Queries, typename GroundTruth>
+template <typename Index, typename Queries, typename GroundTruth, svs::threads::ThreadPool Pool = svs::threads::DefaultThreadPool>
 void test_flat(Index& index, const Queries& queries, const GroundTruth& groundtruth) {
     CATCH_REQUIRE(index.size() == test_dataset::VECTORS_IN_DATA_SET);
     CATCH_REQUIRE(index.dimensions() == test_dataset::NUM_DIMENSIONS);
@@ -93,7 +93,7 @@ void test_flat(Index& index, const Queries& queries, const GroundTruth& groundtr
     auto result = svs::QueryResult<size_t>(groundtruth.size(), groundtruth.dimensions());
 
     for (auto num_threads : std::array<size_t, 2>{{1, 2}}) {
-        index.set_num_threads(num_threads);
+        index.set_threadpool(Pool(num_threads));
         CATCH_REQUIRE((index.get_num_threads() == num_threads));
         svs::index::search_batch_into(index, result.view(), queries.cview());
         // index.search(queries.cview(), groundtruth.dimensions(), result.view());
@@ -101,7 +101,7 @@ void test_flat(Index& index, const Queries& queries, const GroundTruth& groundtr
     }
 
     // Set different data and query batch sizes.
-    index.set_num_threads(2);
+    index.set_threadpool(Pool(2));
     for (size_t query_batch_size : {0, 10}) {
         for (size_t data_batch_size : {0, 100}) {
             svs::index::search_batch_into_with(
@@ -124,7 +124,7 @@ void test_flat(Index& index, const Queries& queries, const GroundTruth& groundtr
 /////
 
 // Test the single-threaded implementation.
-CATCH_TEST_CASE("Flat Index Search", "[integration][exhaustive]") {
+CATCH_TEST_CASE("Flat Index Search", "[integration][exhaustive][index]") {
     auto queries = test_dataset::queries();
     auto data = svs::load_data<float>(test_dataset::data_svs_file());
 
@@ -135,9 +135,9 @@ CATCH_TEST_CASE("Flat Index Search", "[integration][exhaustive]") {
         auto groundtruth = test_dataset::groundtruth_euclidean();
         // test the temporary index.
         {
-            auto threadpool = svs::threads::NativeThreadPool(4);
+            auto threadpool = svs::threads::DefaultThreadPool(4);
             auto temp = svs::index::flat::temporary_flat_index(
-                data, svs::distance::DistanceL2(), threadpool
+                data, svs::distance::DistanceL2(), svs::threads::ThreadPoolReferenceWrapper(threadpool)
             );
             test_flat(temp, queries, groundtruth);
         }
@@ -168,13 +168,42 @@ CATCH_TEST_CASE("Flat Index Search", "[integration][exhaustive]") {
             svs::index::flat::FlatIndex{std::move(data), svs_test::StatefulL2<float>{}, 1};
         test_flat(index, queries, groundtruth);
     }
+
+    CATCH_SECTION("Flat Index With CppAyncThreadPool - IP") {
+        auto groundtruth = test_dataset::groundtruth_mip();
+        auto index = svs::index::flat::FlatIndex(
+            std::move(data), svs::distance::DistanceIP{}, svs::threads::CppAsyncThreadPool(2)
+        );
+        test_flat<decltype(index), decltype(queries), decltype(groundtruth), svs::threads::CppAsyncThreadPool>(index, queries, groundtruth);
+        auto& threadpool = index.get_threadpool_handle().get<svs::threads::CppAsyncThreadPool>();
+        threadpool.resize(3);
+        CATCH_REQUIRE(index.get_num_threads() == 3);
+        test_flat<decltype(index), decltype(queries), decltype(groundtruth), svs::threads::CppAsyncThreadPool>(index, queries, groundtruth);
+    }
+
+    CATCH_SECTION("Flat Index With QueueThreadPoolWrapper - Cosine") {
+        auto groundtruth = test_dataset::groundtruth_cosine();
+        auto index = svs::index::flat::FlatIndex(
+            std::move(data), svs::distance::DistanceCosineSimilarity{}, svs::threads::QueueThreadPoolWrapper(2)
+        );
+        test_flat<decltype(index), decltype(queries), decltype(groundtruth), svs::threads::QueueThreadPoolWrapper>(index, queries, groundtruth);
+    }
+
+    CATCH_SECTION("Flat Index With Different Thread Pools - Cosine") {
+        auto groundtruth = test_dataset::groundtruth_cosine();
+        auto index = svs::index::flat::FlatIndex(
+            std::move(data), svs::distance::DistanceCosineSimilarity{}, svs::threads::QueueThreadPoolWrapper(2)
+        );
+        test_flat<decltype(index), decltype(queries), decltype(groundtruth), svs::threads::CppAsyncThreadPool>(index, queries, groundtruth);
+        test_flat(index, queries, groundtruth);
+    }
 }
 
 /////
 ///// Flat
 /////
 
-CATCH_TEST_CASE("Flat Orchestrator Search", "[integration][exhaustive]") {
+CATCH_TEST_CASE("Flat Orchestrator Search", "[integration][exhaustive][orchestrator]") {
     auto queries = test_dataset::queries();
 
     // Load data using both the file path method and from a direct file.
@@ -231,5 +260,34 @@ CATCH_TEST_CASE("Flat Orchestrator Search", "[integration][exhaustive]") {
         index = svs::Flat::assemble<float>(std::move(data), svs::Cosine, 2);
         CATCH_REQUIRE(index.get_num_threads() == 2);
         test_flat(index, queries, test_dataset::groundtruth_cosine());
+    }
+
+    CATCH_SECTION("Cosine With Different Thread Pools From File") {
+        svs::Flat index = svs::Flat::assemble<float>(
+            svs::VectorDataLoader<float>(test_dataset::data_svs_file()), svs::Cosine, svs::threads::CppAsyncThreadPool(2)
+        );
+        CATCH_REQUIRE(index.get_num_threads() == 2);
+
+        auto& threadpool = index.get_threadpool_handle().get<svs::threads::CppAsyncThreadPool>();
+        threadpool.resize(3);
+        CATCH_REQUIRE(index.get_num_threads() == 3);
+        test_flat<decltype(index), decltype(queries), decltype(test_dataset::groundtruth_cosine()), svs::threads::CppAsyncThreadPool>(index, queries, test_dataset::groundtruth_cosine());
+
+        index.set_threadpool(svs::threads::DefaultThreadPool(3));
+        test_flat<decltype(index), decltype(queries), decltype(test_dataset::groundtruth_cosine()), svs::threads::DefaultThreadPool>(index, queries, test_dataset::groundtruth_cosine());
+
+        test_flat<decltype(index), decltype(queries), decltype(test_dataset::groundtruth_cosine()), svs::threads::QueueThreadPoolWrapper>(index, queries, test_dataset::groundtruth_cosine());
+    }
+
+    CATCH_SECTION("Cosine With Different Thread Pools From Data") {
+        svs::Flat index = svs::Flat::assemble<float>(std::move(data), svs::Cosine, svs::threads::QueueThreadPoolWrapper(3));
+        CATCH_REQUIRE(index.get_num_threads() == 3);
+        test_flat<decltype(index), decltype(queries), decltype(test_dataset::groundtruth_cosine()), svs::threads::QueueThreadPoolWrapper>(index, queries, test_dataset::groundtruth_cosine());
+
+        index.set_threadpool(svs::threads::CppAsyncThreadPool(2));
+        CATCH_REQUIRE(index.get_num_threads() == 2);
+        test_flat<decltype(index), decltype(queries), decltype(test_dataset::groundtruth_cosine()), svs::threads::CppAsyncThreadPool>(index, queries, test_dataset::groundtruth_cosine());
+
+        test_flat<decltype(index), decltype(queries), decltype(test_dataset::groundtruth_cosine()), svs::threads::DefaultThreadPool>(index, queries, test_dataset::groundtruth_cosine());
     }
 }

--- a/tests/integration/inverted/build.cpp
+++ b/tests/integration/inverted/build.cpp
@@ -33,7 +33,12 @@
 
 namespace {
 
-template <typename E, typename Distance, typename ClusterStrategy, svs::threads::ThreadPool Pool, size_t D = svs::Dynamic>
+template <
+    typename E,
+    typename Distance,
+    typename ClusterStrategy,
+    svs::threads::ThreadPool Pool,
+    size_t D = svs::Dynamic>
 svs::Inverted build_index(
     const svs::index::inverted::InvertedBuildParameters& build_parameters,
     const std::filesystem::path& data_path,
@@ -96,7 +101,8 @@ void run_test(const Queries& queries, ThreadPoolProto threadpool_proto) {
             );
             CATCH_REQUIRE(recall > expected.recall_ - epsilon);
             CATCH_REQUIRE(recall < expected.recall_ + epsilon);
-            auto& threadpool = index.get_threadpool_handle().get<svs::threads::DefaultThreadPool>();
+            auto& threadpool =
+                index.get_threadpool_handle().get<svs::threads::DefaultThreadPool>();
             threadpool.resize(3);
             CATCH_REQUIRE(index.get_num_threads() == 3);
         }
@@ -108,8 +114,14 @@ void run_test(const Queries& queries, ThreadPoolProto threadpool_proto) {
 CATCH_TEST_CASE("Test Inverted Building", "[integration][build][inverted]") {
     auto queries = svs::data::SimpleData<float>::load(test_dataset::query_file());
     run_test<svs::DistanceL2, svs::index::inverted::SparseStrategy>(queries, 2);
-    run_test<svs::DistanceL2, svs::index::inverted::DenseStrategy>(queries, svs::threads::DefaultThreadPool(2));
+    run_test<svs::DistanceL2, svs::index::inverted::DenseStrategy>(
+        queries, svs::threads::DefaultThreadPool(2)
+    );
     run_test<svs::DistanceIP, svs::index::inverted::SparseStrategy>(queries, 3);
-    run_test<svs::DistanceIP, svs::index::inverted::DenseStrategy>(queries, svs::threads::CppAsyncThreadPool(3));
-    run_test<svs::DistanceIP, svs::index::inverted::SparseStrategy>(queries, svs::threads::QueueThreadPoolWrapper(2));
+    run_test<svs::DistanceIP, svs::index::inverted::DenseStrategy>(
+        queries, svs::threads::CppAsyncThreadPool(3)
+    );
+    run_test<svs::DistanceIP, svs::index::inverted::SparseStrategy>(
+        queries, svs::threads::QueueThreadPoolWrapper(2)
+    );
 }

--- a/tests/integration/inverted/build.cpp
+++ b/tests/integration/inverted/build.cpp
@@ -33,11 +33,11 @@
 
 namespace {
 
-template <typename E, typename Distance, typename ClusterStrategy, size_t D = svs::Dynamic>
+template <typename E, typename Distance, typename ClusterStrategy, svs::threads::ThreadPool Pool, size_t D = svs::Dynamic>
 svs::Inverted build_index(
     const svs::index::inverted::InvertedBuildParameters& build_parameters,
     const std::filesystem::path& data_path,
-    size_t num_threads,
+    Pool threadpool,
     Distance distance,
     ClusterStrategy strategy
 ) {
@@ -46,22 +46,20 @@ svs::Inverted build_index(
         build_parameters,
         svs::data::SimpleData<E, D>::load(data_path),
         distance,
-        num_threads,
+        std::move(threadpool),
         strategy
     );
     fmt::print("Indexing time: {}s\n", svs::lib::time_difference(tic));
-    CATCH_REQUIRE(index.get_num_threads() == num_threads);
     return index;
 }
 
-template <typename Distance, typename Strategy, typename Queries>
-void run_test(const Queries& queries) {
+template <typename Distance, typename Strategy, typename Queries, typename ThreadPoolProto>
+void run_test(const Queries& queries, ThreadPoolProto threadpool_proto) {
     auto distance = Distance();
     auto strategy = Strategy();
 
     // Distance between the obtained results and reference ressults.
     const double epsilon = 0.005;
-    size_t num_threads = 2;
     constexpr svs::DistanceType distance_type = svs::distance_type_v<decltype(distance)>;
     auto expected_results = test_dataset::inverted::expected_build_results(
         distance_type, svsbenchmark::Uncompressed(svs::DataType::float32)
@@ -70,7 +68,7 @@ void run_test(const Queries& queries) {
     svs::Inverted index = build_index<float>(
         expected_results.build_parameters_.value(),
         test_dataset::data_svs_file(),
-        num_threads,
+        svs::threads::as_threadpool(std::move(threadpool_proto)),
         distance,
         strategy
     );
@@ -85,7 +83,7 @@ void run_test(const Queries& queries) {
         index.set_search_parameters(sp);
         CATCH_REQUIRE(index.get_search_parameters() == sp);
         for (size_t num_threads : {1, 2}) {
-            index.set_num_threads(num_threads);
+            index.set_threadpool(svs::threads::DefaultThreadPool(num_threads));
             CATCH_REQUIRE(index.get_num_threads() == num_threads);
 
             auto results = index.search(these_queries, expected.num_neighbors_);
@@ -98,6 +96,9 @@ void run_test(const Queries& queries) {
             );
             CATCH_REQUIRE(recall > expected.recall_ - epsilon);
             CATCH_REQUIRE(recall < expected.recall_ + epsilon);
+            auto& threadpool = index.get_threadpool_handle().get<svs::threads::DefaultThreadPool>();
+            threadpool.resize(3);
+            CATCH_REQUIRE(index.get_num_threads() == 3);
         }
     }
 }
@@ -106,9 +107,9 @@ void run_test(const Queries& queries) {
 
 CATCH_TEST_CASE("Test Inverted Building", "[integration][build][inverted]") {
     auto queries = svs::data::SimpleData<float>::load(test_dataset::query_file());
-    run_test<svs::DistanceL2, svs::index::inverted::SparseStrategy>(queries);
-    run_test<svs::DistanceL2, svs::index::inverted::DenseStrategy>(queries);
-
-    run_test<svs::DistanceIP, svs::index::inverted::SparseStrategy>(queries);
-    run_test<svs::DistanceIP, svs::index::inverted::SparseStrategy>(queries);
+    run_test<svs::DistanceL2, svs::index::inverted::SparseStrategy>(queries, 2);
+    run_test<svs::DistanceL2, svs::index::inverted::DenseStrategy>(queries, svs::threads::DefaultThreadPool(2));
+    run_test<svs::DistanceIP, svs::index::inverted::SparseStrategy>(queries, 3);
+    run_test<svs::DistanceIP, svs::index::inverted::DenseStrategy>(queries, svs::threads::CppAsyncThreadPool(3));
+    run_test<svs::DistanceIP, svs::index::inverted::SparseStrategy>(queries, svs::threads::QueueThreadPoolWrapper(2));
 }

--- a/tests/integration/vamana/index_build.cpp
+++ b/tests/integration/vamana/index_build.cpp
@@ -42,7 +42,10 @@
 
 namespace {
 
-template <typename E, size_t D = svs::Dynamic, svs::threads::ThreadPool Pool = svs::threads::DefaultThreadPool>
+template <
+    typename E,
+    size_t D = svs::Dynamic,
+    svs::threads::ThreadPool Pool = svs::threads::DefaultThreadPool>
 svs::Vamana build_index(
     const svs::index::vamana::VamanaBuildParameters parameters,
     const std::filesystem::path& data_path,
@@ -51,7 +54,10 @@ svs::Vamana build_index(
 ) {
     auto tic = svs::lib::now();
     svs::Vamana index = svs::Vamana::build<E>(
-        parameters, svs::data::SimpleData<E, D>::load(data_path), dist_type, std::move(threadpool)
+        parameters,
+        svs::data::SimpleData<E, D>::load(data_path),
+        dist_type,
+        std::move(threadpool)
     );
 
     fmt::print("Indexing time: {}s\n", svs::lib::time_difference(tic));
@@ -124,7 +130,10 @@ CATCH_TEST_CASE("Uncompressed Vamana Build", "[integration][build][vamana]") {
     }
 }
 
-CATCH_TEST_CASE("Uncompressed Vamana Build With Different Threadpools", "[integration][build][vamana][threadpool]") {
+CATCH_TEST_CASE(
+    "Uncompressed Vamana Build With Different Threadpools",
+    "[integration][build][vamana][threadpool]"
+) {
     auto distances = std::to_array<svs::DistanceType>({svs::L2, svs::MIP, svs::Cosine});
 
     // How far these results may deviate from previously generated results.
@@ -182,7 +191,8 @@ CATCH_TEST_CASE("Uncompressed Vamana Build With Different Threadpools", "[integr
             CATCH_REQUIRE(recall > expected.recall_ - epsilon);
             CATCH_REQUIRE(recall < expected.recall_ + epsilon);
 
-            auto& threadpool = index.get_threadpool_handle().get<svs::threads::CppAsyncThreadPool>();
+            auto& threadpool =
+                index.get_threadpool_handle().get<svs::threads::CppAsyncThreadPool>();
             threadpool.resize(2);
             CATCH_REQUIRE(index.get_num_threads() == 2);
         }

--- a/tests/integration/vamana/index_build.cpp
+++ b/tests/integration/vamana/index_build.cpp
@@ -42,6 +42,23 @@
 
 namespace {
 
+template <typename E, size_t D = svs::Dynamic, svs::threads::ThreadPool Pool = svs::threads::DefaultThreadPool>
+svs::Vamana build_index(
+    const svs::index::vamana::VamanaBuildParameters parameters,
+    const std::filesystem::path& data_path,
+    Pool threadpool,
+    svs::DistanceType dist_type
+) {
+    auto tic = svs::lib::now();
+    svs::Vamana index = svs::Vamana::build<E>(
+        parameters, svs::data::SimpleData<E, D>::load(data_path), dist_type, std::move(threadpool)
+    );
+
+    fmt::print("Indexing time: {}s\n", svs::lib::time_difference(tic));
+
+    return index;
+}
+
 template <typename E, size_t D = svs::Dynamic>
 svs::Vamana build_index(
     const svs::index::vamana::VamanaBuildParameters parameters,
@@ -104,5 +121,71 @@ CATCH_TEST_CASE("Uncompressed Vamana Build", "[integration][build][vamana]") {
             CATCH_REQUIRE(recall > expected.recall_ - epsilon);
             CATCH_REQUIRE(recall < expected.recall_ + epsilon);
         }
+    }
+}
+
+CATCH_TEST_CASE("Uncompressed Vamana Build With Different Threadpools", "[integration][build][vamana][threadpool]") {
+    auto distances = std::to_array<svs::DistanceType>({svs::L2, svs::MIP, svs::Cosine});
+
+    // How far these results may deviate from previously generated results.
+    const double epsilon = 0.005;
+    const auto queries = svs::data::SimpleData<float>::load(test_dataset::query_file());
+    size_t num_threads = 1;
+    for (auto distance_type : distances) {
+        CATCH_REQUIRE(svs_test::prepare_temp_directory());
+        auto expected_result = test_dataset::vamana::expected_build_results(
+            distance_type, svsbenchmark::Uncompressed(svs::DataType::float32)
+        );
+        svs::Vamana index = build_index<float>(
+            expected_result.build_parameters_.value(),
+            test_dataset::data_svs_file(),
+            svs::threads::DefaultThreadPool(num_threads),
+            distance_type
+        );
+        CATCH_REQUIRE(
+            index.query_types() == std::vector<svs::DataType>{svs::DataType::float32}
+        );
+
+        auto groundtruth = test_dataset::load_groundtruth(distance_type);
+        for (const auto& expected : expected_result.config_and_recall_) {
+            auto these_queries = test_dataset::get_test_set(queries, expected.num_queries_);
+            auto these_groundtruth =
+                test_dataset::get_test_set(groundtruth, expected.num_queries_);
+            index.set_search_parameters(expected.search_parameters_);
+            auto results = index.search(these_queries, expected.num_neighbors_);
+            double recall = svs::k_recall_at_n(
+                these_groundtruth, results, expected.num_neighbors_, expected.recall_k_
+            );
+
+            fmt::print(
+                "Window Size: {}, Expected Recall: {}, Actual Recall: {}\n",
+                index.get_search_window_size(),
+                expected.recall_,
+                recall
+            );
+            CATCH_REQUIRE(recall > expected.recall_ - epsilon);
+            CATCH_REQUIRE(recall < expected.recall_ + epsilon);
+
+            index.set_threadpool(svs::threads::CppAsyncThreadPool(num_threads));
+
+            CATCH_REQUIRE(index.get_num_threads() == num_threads);
+            results = index.search(these_queries, expected.num_neighbors_);
+            recall = svs::k_recall_at_n(
+                these_groundtruth, results, expected.num_neighbors_, expected.recall_k_
+            );
+            fmt::print(
+                "Window Size: {}, Expected Recall: {}, Actual Recall: {}\n",
+                index.get_search_window_size(),
+                expected.recall_,
+                recall
+            );
+            CATCH_REQUIRE(recall > expected.recall_ - epsilon);
+            CATCH_REQUIRE(recall < expected.recall_ + epsilon);
+
+            auto& threadpool = index.get_threadpool_handle().get<svs::threads::CppAsyncThreadPool>();
+            threadpool.resize(2);
+            CATCH_REQUIRE(index.get_num_threads() == 2);
+        }
+        ++num_threads;
     }
 }

--- a/tests/integration/vamana/index_search.cpp
+++ b/tests/integration/vamana/index_search.cpp
@@ -278,7 +278,9 @@ CATCH_TEST_CASE("Uncompressed Vamana Search", "[integration][search][vamana]") {
             svs::threads::CppAsyncThreadPool(2)
         );
 
-        run_tests<svs::threads::CppAsyncThreadPool>(index, queries, groundtruth, expected_results.config_and_recall_, true);
+        run_tests<svs::threads::CppAsyncThreadPool>(
+            index, queries, groundtruth, expected_results.config_and_recall_, true
+        );
 
         index = svs::Vamana::assemble<svs::lib::Types<float, svs::Float16>>(
             test_dataset::vamana_config_file(),
@@ -288,7 +290,9 @@ CATCH_TEST_CASE("Uncompressed Vamana Search", "[integration][search][vamana]") {
             svs::threads::QueueThreadPoolWrapper(2)
         );
 
-        run_tests<svs::threads::QueueThreadPoolWrapper>(index, queries, groundtruth, expected_results.config_and_recall_, true);
+        run_tests<svs::threads::QueueThreadPoolWrapper>(
+            index, queries, groundtruth, expected_results.config_and_recall_, true
+        );
         // Save and reload.
         svs_test::prepare_temp_directory();
 
@@ -328,9 +332,12 @@ CATCH_TEST_CASE("Uncompressed Vamana Search", "[integration][search][vamana]") {
 
         index.set_threadpool(svs::threads::CppAsyncThreadPool(1));
         CATCH_REQUIRE(index.get_num_threads() == 1);
-        auto& threadpool = index.get_threadpool_handle().get<svs::threads::CppAsyncThreadPool>();
+        auto& threadpool =
+            index.get_threadpool_handle().get<svs::threads::CppAsyncThreadPool>();
         threadpool.resize(2);
         CATCH_REQUIRE(index.get_num_threads() == 2);
-        run_tests<svs::threads::CppAsyncThreadPool>(index, queries, groundtruth, expected_results.config_and_recall_);
+        run_tests<svs::threads::CppAsyncThreadPool>(
+            index, queries, groundtruth, expected_results.config_and_recall_
+        );
     }
 }

--- a/tests/svs/core/compact.cpp
+++ b/tests/svs/core/compact.cpp
@@ -72,7 +72,7 @@ CATCH_TEST_CASE("Simple Data Compaction", "[core][compaction]") {
         // Reset and go again, this time with two threads.
         sequential_fill(data);
         CATCH_REQUIRE(check_sequential(data));
-        auto tpool = svs::threads::NativeThreadPool(2);
+        auto tpool = svs::threads::DefaultThreadPool(2);
         data.compact(svs::lib::as_const_span(new_to_old), tpool);
         for (size_t i = 0, imax = new_to_old.size(); i < imax; ++i) {
             auto val = new_to_old.at(i);
@@ -118,7 +118,7 @@ CATCH_TEST_CASE("Simple Data Compaction", "[core][compaction]") {
         // Multi-threaded version.
         sequential_fill(data);
         CATCH_REQUIRE(check_sequential(data));
-        auto tpool = svs::threads::NativeThreadPool(2);
+        auto tpool = svs::threads::DefaultThreadPool(2);
         data.compact(svs::lib::as_const_span(new_to_old), tpool, 20);
         for (size_t i = 0, imax = new_to_old.size(); i < imax; ++i) {
             auto val = new_to_old.at(i);

--- a/tests/svs/core/kmeans.cpp
+++ b/tests/svs/core/kmeans.cpp
@@ -91,7 +91,7 @@ CATCH_TEST_CASE("KMeans Clustering", "[core][kmeans]") {
             }
         }
 
-        auto threadpool = svs::threads::NativeThreadPool(4);
+        auto threadpool = svs::threads::DefaultThreadPool(4);
         double mse = svs::mean_squared_error(data, centroids, threadpool);
         double expected_mse = centroids.dimensions() * ((0.5 * 0.5) + (1.5 * 1.5)) / 2;
         CATCH_REQUIRE(mse == expected_mse);

--- a/tests/svs/core/medioid.cpp
+++ b/tests/svs/core/medioid.cpp
@@ -144,7 +144,7 @@ CATCH_TEST_CASE("Testing Medioid Computation", "[core][medioid]") {
     }
 
     CATCH_SECTION("Parallelized") {
-        svs::threads::NativeThreadPool threadpool(2);
+        svs::threads::DefaultThreadPool threadpool(2);
 
         // No predicate
         auto tic = svs::lib::now();
@@ -176,7 +176,7 @@ CATCH_TEST_CASE("Testing Medioid Computation", "[core][medioid]") {
     }
 
     CATCH_SECTION("Find Medioid") {
-        svs::threads::NativeThreadPool threadpool(2);
+        svs::threads::DefaultThreadPool threadpool(2);
         size_t index = svs::utils::find_medioid(
             data, threadpool, returns_true, svs::lib::identity(), test_parameters
         );
@@ -191,7 +191,7 @@ CATCH_TEST_CASE("Testing Medioid Computation", "[core][medioid]") {
         std::vector<double> ref = compute_variances(data);
 
         // Parallel Computation
-        svs::threads::NativeThreadPool threadpool(2);
+        svs::threads::DefaultThreadPool threadpool(2);
         auto means = svs::utils::compute_medioid(data, threadpool);
         auto variances =
             svs::utils::op_pairwise(data, svs::utils::CountVariance(means), threadpool);

--- a/tests/svs/index/inverted/clustering.cpp
+++ b/tests/svs/index/inverted/clustering.cpp
@@ -37,7 +37,7 @@ svs::index::inverted::Clustering<uint32_t> randomly_cluster(
     const Distance& distance,
     size_t num_threads
 ) {
-    auto threadpool = svs::threads::NativeThreadPool(num_threads);
+    auto threadpool = svs::threads::DefaultThreadPool(num_threads);
 
     // Select Centroids.
     auto centroids = svs::index::inverted::randomly_select_centroids(

--- a/tests/svs/index/vamana/consolidate.cpp
+++ b/tests/svs/index/vamana/consolidate.cpp
@@ -55,7 +55,7 @@ void check_post_conditions(const Graph& graph, Predicate&& predicate) {
 CATCH_TEST_CASE("Graph Consolidation", "[graph_index]") {
     auto graph = test_dataset::graph();
     auto data = test_dataset::data_f32();
-    auto threadpool = svs::threads::NativeThreadPool(2);
+    auto threadpool = svs::threads::DefaultThreadPool(2);
 
     CATCH_SECTION("Remove Even Nodes") {
         auto tic = svs::lib::now();

--- a/tests/svs/index/vamana/dynamic_index.cpp
+++ b/tests/svs/index/vamana/dynamic_index.cpp
@@ -203,7 +203,8 @@ CATCH_TEST_CASE("MutableVamanaIndex", "[graph_index]") {
         index.consolidate();
         index.debug_check_graph_consistency(false);
 
-        auto& threadpool = index.get_threadpool_handle().get<threads::CppAsyncThreadPool>.get();
+        auto& threadpool =
+            index.get_threadpool_handle().get<threads::CppAsyncThreadPool>.get();
         threadpool.resize(3);
         CATCH_REQUIRE(index.get_num_threads() == 3);
         threadpool.resize(num_threads);

--- a/tests/svs/index/vamana/dynamic_index.cpp
+++ b/tests/svs/index/vamana/dynamic_index.cpp
@@ -148,6 +148,8 @@ CATCH_TEST_CASE("MutableVamanaIndex", "[graph_index]") {
             }
         }
 
+        index.set_threadpool(threads::CppAsyncThreadPool(num_threads));
+
         std::cout << "Deleting " << ids_to_delete.size() << " entries!" << std::endl;
         index.delete_entries(ids_to_delete);
         check_deleted(index, ids_to_delete, base_data.size());
@@ -163,6 +165,8 @@ CATCH_TEST_CASE("MutableVamanaIndex", "[graph_index]") {
 
         // Make sure none of the returned results are in the deleted list.
         check_results(results.indices(), ids_to_delete);
+
+        index.set_threadpool(threads::QueueThreadPoolWrapper(num_threads));
 
         auto results_reference = svs::QueryResult<size_t>(queries.size(), num_neighbors);
         index.exhaustive_search(queries.view(), num_neighbors, results_reference.view());
@@ -199,6 +203,12 @@ CATCH_TEST_CASE("MutableVamanaIndex", "[graph_index]") {
         index.consolidate();
         index.debug_check_graph_consistency(false);
 
+        auto& threadpool = index.get_threadpool_handle().get<threads::CppAsyncThreadPool>.get();
+        threadpool.resize(3);
+        CATCH_REQUIRE(index.get_num_threads() == 3);
+        threadpool.resize(num_threads);
+        CATCH_REQUIRE(index.get_num_threads() == num_threads);
+
         CATCH_REQUIRE(index.entry_point() != entry_point);
         index.search(queries.view(), num_neighbors, results.view());
         auto post_entrypoint_recall =
@@ -217,6 +227,7 @@ CATCH_TEST_CASE("MutableVamanaIndex", "[graph_index]") {
             ++i;
         }
 
+        index.set_threadpool(threads::DefaultThreadPool(num_threads));
         tic = svs::lib::now();
         index.add_points(points, ids_to_delete);
         auto insert_time = svs::lib::time_difference(tic);

--- a/tests/svs/index/vamana/dynamic_index_2.cpp
+++ b/tests/svs/index/vamana/dynamic_index_2.cpp
@@ -360,6 +360,49 @@ CATCH_TEST_CASE("Testing Graph Index", "[graph_index][dynamic_index]") {
         2
     );
 
+    do_check(
+        reloaded,
+        reference,
+        queries,
+        build_time,
+        stringify("initial build (", num_indices_to_add, ") points"),
+        true
+    );
+
+    reloaded = svs::index::vamana::auto_dynamic_assemble(
+        tmp / "config",
+        SVS_LAZY(svs::graphs::SimpleBlockedGraph<uint32_t>::load(tmp / "graph")),
+        SVS_LAZY(svs::data::BlockedData<float>::load(tmp / "data")),
+        svs::DistanceL2(),
+        svs::threads::CppAsyncThreadPool(2)
+    );
+
+    do_check(
+        reloaded,
+        reference,
+        queries,
+        build_time,
+        stringify("initial build (", num_indices_to_add, ") points"),
+        true
+    );
+
+    reloaded = svs::index::vamana::auto_dynamic_assemble(
+        tmp / "config",
+        SVS_LAZY(svs::graphs::SimpleBlockedGraph<uint32_t>::load(tmp / "graph")),
+        SVS_LAZY(svs::data::BlockedData<float>::load(tmp / "data")),
+        svs::DistanceL2(),
+        svs::threads::QueueThreadPoolWrapper(2)
+    );
+
+    do_check(
+        reloaded,
+        reference,
+        queries,
+        build_time,
+        stringify("initial build (", num_indices_to_add, ") points"),
+        true
+    );
+
     // Make sure parameters were saved across the saving.
     CATCH_REQUIRE(index.get_alpha() == reloaded.get_alpha());
     CATCH_REQUIRE(index.get_graph_max_degree() == reloaded.get_graph_max_degree());

--- a/tests/svs/index/vamana/iterator.cpp
+++ b/tests/svs/index/vamana/iterator.cpp
@@ -270,7 +270,7 @@ CATCH_TEST_CASE("Vamana Iterator", "[index][vamana][iterator]") {
         auto original = test_dataset::data_f32();
 
         // Increase the number of threads to help a little with run time.
-        index.set_num_threads(2);
+        index.set_threadpool(svs::threads::DefaultThreadPool(2));
         auto itr = svs::threads::UnitRange{0, index.size()};
         auto valid_ids = std::unordered_set<size_t>{itr.begin(), itr.end()};
         auto checker = DynamicChecker{valid_ids};

--- a/tests/svs/index/vamana/vamana_build.cpp
+++ b/tests/svs/index/vamana/vamana_build.cpp
@@ -97,9 +97,9 @@ CATCH_TEST_CASE("Index Build Utilties", "[vamana][vamana_build]") {
         // Entries `[10*i + 4, 20 * i)` will be added by thread 2.
         // The regions added by each thread intentionally overlap to ensure that the
         // buffer correctly handles repeated elements.
-        auto threadpool = svs::threads::NativeThreadPool(2);
+        auto threadpool = svs::threads::DefaultThreadPool(2);
         CATCH_REQUIRE(threadpool.size() == 2);
-        svs::threads::run(threadpool, [&](auto tid) {
+        svs::threads::parallel_for(threadpool, [&](auto tid) {
             // Random number generator per thread.
             std::mt19937_64 engine{std::random_device{}()};
             auto dist = std::uniform_int_distribution<>{1, 10};

--- a/tests/svs/lib/concurrency/readwrite_protected.cpp
+++ b/tests/svs/lib/concurrency/readwrite_protected.cpp
@@ -124,8 +124,8 @@ void stress_test() {
     };
 
     // Run all jobs.
-    auto threadpool = svs::threads::NativeThreadPool(num_writers + num_readers);
-    threadpool.run(svs::threads::FunctionRef{job});
+    auto threadpool = svs::threads::DefaultThreadPool(num_writers + num_readers);
+    threadpool.parallel_for(std::move(job), threadpool.size());
 
     // Make sure the final results make sense.
     // * Final count is correct.

--- a/tests/svs/lib/threads/thread.cpp
+++ b/tests/svs/lib/threads/thread.cpp
@@ -110,15 +110,14 @@ CATCH_TEST_CASE("Basics", "[core][threads]") {
 
     CATCH_SECTION("ThreadFunction") {
         std::vector<int> x{};
-        auto fn = [&x](uint64_t val) { x.push_back(val); };
-        auto ref = svs::threads::FunctionRef(fn);
+        std::function<void(size_t)> fn = [&x](size_t val) { x.push_back(val); };
 
-        svs::threads::ThreadFunctionRef fn_ref{ref, 10};
+        svs::threads::ThreadFunctionRef fn_ref{&fn, 10};
         fn_ref();
         CATCH_REQUIRE(x.size() == 1);
         CATCH_REQUIRE(x.at(0) == 10);
 
-        fn_ref = {ref, 100};
+        fn_ref = {&fn, 100};
         fn_ref();
         CATCH_REQUIRE(x.size() == 2);
         CATCH_REQUIRE(x.at(0) == 10);
@@ -137,8 +136,8 @@ CATCH_TEST_CASE("Control Block", "[core][threads][thread_control_block]") {
 
         // Get and set work.
         std::vector<int> x{};
-        auto fn = [&x](uint64_t val) { x.push_back(val); };
-        svs::threads::ThreadFunctionRef fn_ref = {svs::threads::FunctionRef(fn), 10};
+        std::function<void(size_t)> fn = [&x](uint64_t val) { x.push_back(val); };
+        svs::threads::ThreadFunctionRef fn_ref = {&fn, 10};
         block.unsafe_set_work(fn_ref);
         block.get_work()();
         CATCH_REQUIRE(x.size() == 1);
@@ -149,8 +148,7 @@ CATCH_TEST_CASE("Control Block", "[core][threads][thread_control_block]") {
         auto block =
             svs::threads::ThreadControlBlock<svs::threads::telemetry::ActionTelemetry>();
         std::vector<int> vector;
-        auto lambda = [&vector](uint64_t val) { vector.push_back(val); };
-        auto fn = svs::threads::FunctionRef(lambda);
+        std::function<void(size_t)> fn = [&vector](uint64_t val) { vector.push_back(val); };
 
         CATCH_SECTION("Working to Spinning") {
             auto f = [&block]() {
@@ -166,8 +164,7 @@ CATCH_TEST_CASE("Control Block", "[core][threads][thread_control_block]") {
                 auto thread = std::thread(f);
                 block.assign(fn);
                 auto fn_retrieved = block.get_work();
-                CATCH_REQUIRE(fn_retrieved.fn.fn == nullptr);
-                CATCH_REQUIRE(fn_retrieved.fn.arg == nullptr);
+                CATCH_REQUIRE(fn_retrieved.fn == nullptr);
                 CATCH_REQUIRE(fn_retrieved.thread_id == 123);
                 thread.join();
 
@@ -200,13 +197,13 @@ CATCH_TEST_CASE("Control Block", "[core][threads][thread_control_block]") {
 
                 // The threadstate variable should be set to `Sleeping`.
                 CATCH_REQUIRE(block.get_state() == svs::threads::ThreadState::Sleeping);
-                block.assign({fn, 10});
+                block.assign({&fn, 10});
 
                 thread.join();
                 CATCH_REQUIRE(block.get_state() == svs::threads::ThreadState::Working);
                 CATCH_REQUIRE(slept == true);
                 auto work = block.get_work();
-                CATCH_REQUIRE(work.fn == fn);
+                CATCH_REQUIRE(work.fn == &fn);
                 CATCH_REQUIRE(work.thread_id == 10);
 
                 auto telemetry = block.get_telemetry();
@@ -240,7 +237,7 @@ CATCH_TEST_CASE("Control Block", "[core][threads][thread_control_block]") {
                 CATCH_REQUIRE(block.get_state() == svs::threads::ThreadState::Spinning);
 
                 // Assign work and then let the spawned thread continue.
-                block.assign({fn, 10});
+                block.assign({&fn, 10});
                 wait.store(1);
                 thread.join();
                 CATCH_REQUIRE(block.get_state() == svs::threads::ThreadState::Working);
@@ -248,7 +245,7 @@ CATCH_TEST_CASE("Control Block", "[core][threads][thread_control_block]") {
                 // sleep.
                 CATCH_REQUIRE(slept == false);
                 auto work = block.get_work();
-                CATCH_REQUIRE(work.fn == fn);
+                CATCH_REQUIRE(work.fn == &fn);
                 CATCH_REQUIRE(work.thread_id == 10);
 
                 auto telemetry = block.get_telemetry();
@@ -285,7 +282,7 @@ CATCH_TEST_CASE("Control Block", "[core][threads][thread_control_block]") {
                 CATCH_REQUIRE(block.get_state() == svs::threads::ThreadState::Sleeping);
 
                 // Assign work and then let the spawned thread continue.
-                block.assign({fn, 10});
+                block.assign({&fn, 10});
                 thread.join();
                 CATCH_REQUIRE(block.get_state() == svs::threads::ThreadState::Working);
 
@@ -293,7 +290,7 @@ CATCH_TEST_CASE("Control Block", "[core][threads][thread_control_block]") {
                 // to sleep.
                 CATCH_REQUIRE(slept == true);
                 auto work = block.get_work();
-                CATCH_REQUIRE(work.fn == fn);
+                CATCH_REQUIRE(work.fn == &fn);
                 CATCH_REQUIRE(work.thread_id == 10);
 
                 auto telemetry = block.get_telemetry();
@@ -489,13 +486,12 @@ CATCH_TEST_CASE("Simple Threading", "[core][threads]") {
     // Now that the worker is running, try assigning some jobs to it.
     {
         std::vector<size_t> test_vector{};
-        auto lambda = [&test_vector](size_t i) { test_vector.push_back(i); };
-        auto f = svs::threads::FunctionRef(lambda);
+        std::function<void(size_t)> f = [&test_vector](size_t i) { test_vector.push_back(i); };
 
         // Assign some jobs and wait until finished.
-        block.assign({f, 10});
-        block.assign({f, 20});
-        block.assign({f, 30});
+        block.assign({&f, 10});
+        block.assign({&f, 20});
+        block.assign({&f, 30});
         block.wait_while_busy();
 
         CATCH_REQUIRE(test_vector.size() == 3);
@@ -508,16 +504,14 @@ CATCH_TEST_CASE("Simple Threading", "[core][threads]") {
     {
         std::vector<size_t> test_vector_f{};
         std::vector<float> test_vector_g{};
-        auto f_lambda = [&test_vector_f](size_t i) { test_vector_f.push_back(i); };
-        auto f = svs::threads::FunctionRef(f_lambda);
+        std::function<void(size_t)> f = [&test_vector_f](size_t i) { test_vector_f.push_back(i); };
 
-        auto g_lambda = [&test_vector_g](size_t i) { test_vector_g.push_back(i); };
-        auto g = svs::threads::FunctionRef(g_lambda);
+        std::function<void(size_t)> g = [&test_vector_g](size_t i) { test_vector_g.push_back(i); };
 
-        block.assign({f, 10});
-        block.assign({g, 20});
-        block.assign({f, 30});
-        block.assign({g, 40});
+        block.assign({&f, 10});
+        block.assign({&g, 20});
+        block.assign({&f, 30});
+        block.assign({&g, 40});
         block.wait_while_busy();
 
         CATCH_REQUIRE(test_vector_f.size() == 2);
@@ -552,8 +546,7 @@ CATCH_TEST_CASE("Extented Test", "[core][threads]") {
     std::this_thread::sleep_for(1ms);
 
     auto vector = std::vector<size_t>{};
-    auto lambda = [&vector](size_t i) { vector.push_back(i); };
-    auto f = svs::threads::FunctionRef(lambda);
+    std::function<void(size_t)> f = [&vector](size_t i) { vector.push_back(i); };
 
     // Get a random number generator
     std::mt19937_64 eng{std::random_device{}()};
@@ -561,10 +554,10 @@ CATCH_TEST_CASE("Extented Test", "[core][threads]") {
     constexpr size_t trip_count = 200000;
     for (size_t i = 0; i < trip_count; ++i) {
         if ((i % 4) == 0) {
-            block.assign({f, i});
+            block.assign({&f, i});
         } else {
             std::this_thread::sleep_for(std::chrono::microseconds{dist(eng)});
-            block.assign({f, i});
+            block.assign({&f, i});
         }
     }
     block.wait_while_busy();
@@ -616,20 +609,18 @@ CATCH_TEST_CASE("Exception Handling", "[core][threads]") {
 
     // First, make sure we can submit successful jobs to the worker thread.
     size_t x = 0;
-    auto fn_good_lambda = [&x](uint64_t new_val) { x = new_val; };
-    auto fn_good = svs::threads::FunctionRef(fn_good_lambda);
-    block->assign({fn_good, 10});
+    std::function<void(size_t)> fn_good = [&x](uint64_t new_val) { x = new_val; };
+    block->assign({&fn_good, 10});
     block->wait_while_busy();
     CATCH_REQUIRE(x == 10);
 
     // Now, assign a job that throws an exception.
-    auto fn_bad_lambda = [&x](uint64_t /*new_val*/) {
+    std::function<void(size_t)> fn_bad = [&x](uint64_t /*new_val*/) {
         auto message = std::to_string(x);
         throw std::runtime_error("Something went wrong: " + message);
     };
-    auto fn_bad = svs::threads::FunctionRef(fn_bad_lambda);
 
-    block->assign({fn_bad, 10});
+    block->assign({&fn_bad, 10});
     block->wait_while_busy();
 
     // An error should now be visible.
@@ -666,9 +657,8 @@ CATCH_TEST_CASE("Testing Thread", "[core][threads][high_level]") {
         auto thread = svs::threads::Thread();
         auto other = std::move(thread);
         int x = 0;
-        auto lambda = [&x](uint64_t i) { x = i; };
-        auto f = svs::threads::FunctionRef(lambda);
-        other.assign({f, 10});
+        std::function<void(size_t)> f = [&x](uint64_t i) { x = i; };
+        other.assign({&f, 10});
         other.wait();
         CATCH_REQUIRE(x == 10);
     }
@@ -683,9 +673,8 @@ CATCH_TEST_CASE("Testing Thread", "[core][threads][high_level]") {
         CATCH_REQUIRE(thread.is_shutdown());
         thread = std::move(other);
         int x = 0;
-        auto lambda = [&x](uint64_t i) { x = i; };
-        auto f = svs::threads::FunctionRef(lambda);
-        thread.assign({f, 10});
+        std::function<void(size_t)> f = [&x](uint64_t i) { x = i; };
+        thread.assign({&f, 10});
         thread.wait();
         CATCH_REQUIRE(x == 10);
     }
@@ -702,22 +691,20 @@ CATCH_TEST_CASE("Testing Thread", "[core][threads][high_level]") {
 
         // N.B.: The function `f` can throw if it receives an out-of-bounds
         // Index.
-        auto f_lambda = [&words, &words_dest](uint64_t i) {
+        std::function<void(size_t)> f = [&words, &words_dest](uint64_t i) {
             words_dest.push_back(words.at(i));
         };
-        auto f = svs::threads::FunctionRef(f_lambda);
 
-        auto g_lambda = [&ints_dest](uint64_t i) { ints_dest.push_back(i); };
-        auto g = svs::threads::FunctionRef(g_lambda);
+        std::function<void(size_t)> g = [&ints_dest](uint64_t i) { ints_dest.push_back(i); };
 
         // Assign jobs to the thread and wait for all to complete.
-        thread.assign({f, 2});
-        thread.assign({g, 1});
-        thread.assign({g, 2});
-        thread.assign({f, 1});
-        thread.assign({f, 0});
-        thread.assign({g, 10});
-        thread.assign({g, 4});
+        thread.assign({&f, 2});
+        thread.assign({&g, 1});
+        thread.assign({&g, 2});
+        thread.assign({&f, 1});
+        thread.assign({&f, 0});
+        thread.assign({&g, 10});
+        thread.assign({&g, 4});
         thread.wait();
 
         CATCH_REQUIRE(thread.is_running());
@@ -739,13 +726,12 @@ CATCH_TEST_CASE("Testing Thread", "[core][threads][high_level]") {
 
     CATCH_SECTION("Exception Handling") {
         auto thread = svs::threads::Thread{};
-        auto lambda = [](uint64_t i) {
+        std::function<void(size_t)> fn = [](uint64_t i) {
             throw std::runtime_error("Hello world " + std::to_string(i));
         };
-        auto fn = svs::threads::FunctionRef(lambda);
         try {
-            thread.assign({fn, 0});
-            thread.assign({fn, 1});
+            thread.assign({&fn, 0});
+            thread.assign({&fn, 1});
         } catch (svs::threads::ThreadError& error) {
             CATCH_REQUIRE(
                 error.what() == svs::threads::ThreadError::make_message("Hello world 0")
@@ -757,10 +743,10 @@ CATCH_TEST_CASE("Testing Thread", "[core][threads][high_level]") {
         thread.shutdown();
         thread = svs::threads::Thread{};
         try {
-            thread.assign({fn, 10});
+            thread.assign({&fn, 10});
             // Wait until the thread is asleep.
             std::this_thread::sleep_for(5ms);
-            thread.assign({fn, 20});
+            thread.assign({&fn, 20});
         } catch (svs::threads::ThreadError& error) {
             CATCH_REQUIRE(
                 error.what() == svs::threads::ThreadError::make_message("Hello world 10")

--- a/tests/svs/lib/threads/thread.cpp
+++ b/tests/svs/lib/threads/thread.cpp
@@ -486,7 +486,9 @@ CATCH_TEST_CASE("Simple Threading", "[core][threads]") {
     // Now that the worker is running, try assigning some jobs to it.
     {
         std::vector<size_t> test_vector{};
-        std::function<void(size_t)> f = [&test_vector](size_t i) { test_vector.push_back(i); };
+        std::function<void(size_t)> f = [&test_vector](size_t i) {
+            test_vector.push_back(i);
+        };
 
         // Assign some jobs and wait until finished.
         block.assign({&f, 10});
@@ -504,9 +506,13 @@ CATCH_TEST_CASE("Simple Threading", "[core][threads]") {
     {
         std::vector<size_t> test_vector_f{};
         std::vector<float> test_vector_g{};
-        std::function<void(size_t)> f = [&test_vector_f](size_t i) { test_vector_f.push_back(i); };
+        std::function<void(size_t)> f = [&test_vector_f](size_t i) {
+            test_vector_f.push_back(i);
+        };
 
-        std::function<void(size_t)> g = [&test_vector_g](size_t i) { test_vector_g.push_back(i); };
+        std::function<void(size_t)> g = [&test_vector_g](size_t i) {
+            test_vector_g.push_back(i);
+        };
 
         block.assign({&f, 10});
         block.assign({&g, 20});
@@ -695,7 +701,9 @@ CATCH_TEST_CASE("Testing Thread", "[core][threads][high_level]") {
             words_dest.push_back(words.at(i));
         };
 
-        std::function<void(size_t)> g = [&ints_dest](uint64_t i) { ints_dest.push_back(i); };
+        std::function<void(size_t)> g = [&ints_dest](uint64_t i) {
+            ints_dest.push_back(i);
+        };
 
         // Assign jobs to the thread and wait for all to complete.
         thread.assign({&f, 2});

--- a/tests/svs/lib/threads/threadpool.cpp
+++ b/tests/svs/lib/threads/threadpool.cpp
@@ -157,24 +157,24 @@ CATCH_TEST_CASE("Thread Pool", "[core][threads][threadpool]") {
         ///// Sequential
         /////
         CATCH_SECTION("Sequential") {
-          start_time = std::chrono::steady_clock::now();
-          for (size_t i = 0; i < v.size(); ++i) {
-              v[i] = 1;
-          }
-          stop_time = std::chrono::steady_clock::now();
-          time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
-          std::cout << "Sequential Loop: " << time_seconds << " seconds" << std::endl;
+            start_time = std::chrono::steady_clock::now();
+            for (size_t i = 0; i < v.size(); ++i) {
+                v[i] = 1;
+            }
+            stop_time = std::chrono::steady_clock::now();
+            time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
+            std::cout << "Sequential Loop: " << time_seconds << " seconds" << std::endl;
 
-          start_time = std::chrono::steady_clock::now();
-          for (size_t i = 0; i < v.size(); ++i) {
-              v[i] = 1;
-          }
-          stop_time = std::chrono::steady_clock::now();
-          time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
-          std::cout << "Sequential Loop: " << time_seconds << " seconds" << std::endl;
-          CATCH_REQUIRE(std::all_of(v.begin(), v.end(), [](const uint64_t& v) {
-              return v == 1;
-          }));
+            start_time = std::chrono::steady_clock::now();
+            for (size_t i = 0; i < v.size(); ++i) {
+                v[i] = 1;
+            }
+            stop_time = std::chrono::steady_clock::now();
+            time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
+            std::cout << "Sequential Loop: " << time_seconds << " seconds" << std::endl;
+            CATCH_REQUIRE(std::all_of(v.begin(), v.end(), [](const uint64_t& v) {
+                return v == 1;
+            }));
         }
 
         /////
@@ -184,16 +184,21 @@ CATCH_TEST_CASE("Thread Pool", "[core][threads][threadpool]") {
         CATCH_SECTION("SequentialThreadPool") {
             auto sequential_pool = svs::threads::SequentialThreadPool{};
             start_time = std::chrono::steady_clock::now();
-            svs::threads::parallel_for(sequential_pool, svs::threads::StaticPartition{v.size()}, f);
+            svs::threads::parallel_for(
+                sequential_pool, svs::threads::StaticPartition{v.size()}, f
+            );
             stop_time = std::chrono::steady_clock::now();
             time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
             std::cout << "Sequential Pool: " << time_seconds << " seconds" << std::endl;
 
             start_time = std::chrono::steady_clock::now();
-            svs::threads::parallel_for(sequential_pool, svs::threads::StaticPartition{v.size()}, f);
+            svs::threads::parallel_for(
+                sequential_pool, svs::threads::StaticPartition{v.size()}, f
+            );
             stop_time = std::chrono::steady_clock::now();
             time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
-            std::cout << "SequentialThreadPool: " << time_seconds << " seconds" << std::endl;
+            std::cout << "SequentialThreadPool: " << time_seconds << " seconds"
+                      << std::endl;
 
             CATCH_REQUIRE(std::all_of(v.begin(), v.end(), [](const uint64_t& v) {
                 return v == 2;

--- a/tests/svs/lib/threads/threadpool.cpp
+++ b/tests/svs/lib/threads/threadpool.cpp
@@ -38,13 +38,13 @@ CATCH_TEST_CASE("Thread Pool", "[core][threads][threadpool]") {
         auto v = std::vector<uint64_t>{};
         auto v_mutex = std::mutex{};
 
-        auto pool = svs::threads::NativeThreadPool(4);
+        auto pool = svs::threads::DefaultThreadPool(4);
         CATCH_SECTION("Just One Thread Crashed") {
             for (size_t i = 0; i < pool.size(); ++i) {
                 v.clear();
                 CATCH_REQUIRE(v.empty());
                 try {
-                    svs::threads::run(pool, [&v, &v_mutex, i](uint64_t tid) {
+                    svs::threads::parallel_for(pool, [&v, &v_mutex, i](uint64_t tid) {
                         if (tid == i) {
                             throw std::runtime_error("This is a test");
                         } else {
@@ -72,7 +72,7 @@ CATCH_TEST_CASE("Thread Pool", "[core][threads][threadpool]") {
         CATCH_SECTION("All Threads Crash") {
             v.clear();
             try {
-                svs::threads::run(pool, [](uint64_t tid) {
+                svs::threads::parallel_for(pool, [](uint64_t tid) {
                     throw std::runtime_error("I crashed " + std::to_string(tid));
                 });
             } catch (const svs::threads::ThreadingException& error) {
@@ -86,7 +86,7 @@ CATCH_TEST_CASE("Thread Pool", "[core][threads][threadpool]") {
             }
 
             // Now try again - all threads should be restarted.
-            svs::threads::run(pool, [&v, &v_mutex](uint64_t tid) {
+            svs::threads::parallel_for(pool, [&v, &v_mutex](uint64_t tid) {
                 std::lock_guard lock{v_mutex};
                 v.push_back(tid);
             });
@@ -99,7 +99,7 @@ CATCH_TEST_CASE("Thread Pool", "[core][threads][threadpool]") {
 
     CATCH_SECTION("Static Partition") {
         namespace threads = svs::threads;
-        auto pool = svs::threads::NativeThreadPool(4);
+        auto pool = svs::threads::DefaultThreadPool(4);
         std::mutex mutex;
 
         std::vector<uint64_t> seen_threads{};
@@ -111,7 +111,7 @@ CATCH_TEST_CASE("Thread Pool", "[core][threads][threadpool]") {
         // 1. Everything remains within bounds.
         // 2. Threads that have no work are never launched.
         CATCH_SECTION("No Oversubscription") {
-            threads::run(
+            threads::parallel_for(
                 pool,
                 threads::StaticPartition(size_t{3}),
                 [&](const auto& range, uint64_t tid) {
@@ -140,35 +140,12 @@ CATCH_TEST_CASE("Thread Pool", "[core][threads][threadpool]") {
         CATCH_REQUIRE(ranges[2] == threads::UnitRange<uint64_t>(2, 3));
     }
 
-    CATCH_SECTION("Parallel versus Sequential") {
+    CATCH_SECTION("Sequential and Parallel For") {
         auto v = std::vector<uint64_t>(100'000);
         constexpr size_t num_threads = 2;
-
-        /////
-        ///// Sequential
-        /////
         auto start_time = std::chrono::steady_clock::now();
-        for (size_t i = 0; i < v.size(); ++i) {
-            v[i] = 1;
-        }
         auto stop_time = std::chrono::steady_clock::now();
-        auto time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
-        std::cout << "Sequential Loop: " << time_seconds << " seconds" << std::endl;
-
-        start_time = std::chrono::steady_clock::now();
-        for (size_t i = 0; i < v.size(); ++i) {
-            v[i] = 1;
-        }
-        stop_time = std::chrono::steady_clock::now();
-        time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
-        std::cout << "Sequential Loop: " << time_seconds << " seconds" << std::endl;
-        CATCH_REQUIRE(std::all_of(v.begin(), v.end(), [](const uint64_t& v) {
-            return v == 1;
-        }));
-
-        /////
-        ///// Sequential ThreadPool
-        /////
+        float time_seconds;
 
         auto f = [&v](const auto& is, size_t /*unused*/) {
             for (auto i : is) {
@@ -176,38 +153,118 @@ CATCH_TEST_CASE("Thread Pool", "[core][threads][threadpool]") {
             }
         };
 
-        auto sequential_pool = svs::threads::SequentialThreadPool{};
-        start_time = std::chrono::steady_clock::now();
-        svs::threads::run(sequential_pool, svs::threads::StaticPartition{v.size()}, f);
-        stop_time = std::chrono::steady_clock::now();
-        time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
-        std::cout << "Sequential Pool: " << time_seconds << " seconds" << std::endl;
+        /////
+        ///// Sequential
+        /////
+        CATCH_SECTION("Sequential") {
+          start_time = std::chrono::steady_clock::now();
+          for (size_t i = 0; i < v.size(); ++i) {
+              v[i] = 1;
+          }
+          stop_time = std::chrono::steady_clock::now();
+          time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
+          std::cout << "Sequential Loop: " << time_seconds << " seconds" << std::endl;
 
-        start_time = std::chrono::steady_clock::now();
-        svs::threads::run(sequential_pool, svs::threads::StaticPartition{v.size()}, f);
-        stop_time = std::chrono::steady_clock::now();
-        time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
-        std::cout << "Sequential Pool: " << time_seconds << " seconds" << std::endl;
+          start_time = std::chrono::steady_clock::now();
+          for (size_t i = 0; i < v.size(); ++i) {
+              v[i] = 1;
+          }
+          stop_time = std::chrono::steady_clock::now();
+          time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
+          std::cout << "Sequential Loop: " << time_seconds << " seconds" << std::endl;
+          CATCH_REQUIRE(std::all_of(v.begin(), v.end(), [](const uint64_t& v) {
+              return v == 1;
+          }));
+        }
 
         /////
-        ///// Parallal
+        ///// Sequential ThreadPool
         /////
 
-        auto pool = svs::threads::NativeThreadPool(num_threads);
-        start_time = std::chrono::steady_clock::now();
-        svs::threads::run(pool, svs::threads::StaticPartition{v.size()}, f);
-        stop_time = std::chrono::steady_clock::now();
-        time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
-        std::cout << "Parallel: " << time_seconds << " seconds" << std::endl;
+        CATCH_SECTION("SequentialThreadPool") {
+            auto sequential_pool = svs::threads::SequentialThreadPool{};
+            start_time = std::chrono::steady_clock::now();
+            svs::threads::parallel_for(sequential_pool, svs::threads::StaticPartition{v.size()}, f);
+            stop_time = std::chrono::steady_clock::now();
+            time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
+            std::cout << "Sequential Pool: " << time_seconds << " seconds" << std::endl;
 
-        start_time = std::chrono::steady_clock::now();
-        svs::threads::run(pool, svs::threads::StaticPartition{v.size()}, f);
-        stop_time = std::chrono::steady_clock::now();
-        time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
-        std::cout << "Parallel: " << time_seconds << " seconds" << std::endl;
+            start_time = std::chrono::steady_clock::now();
+            svs::threads::parallel_for(sequential_pool, svs::threads::StaticPartition{v.size()}, f);
+            stop_time = std::chrono::steady_clock::now();
+            time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
+            std::cout << "SequentialThreadPool: " << time_seconds << " seconds" << std::endl;
 
-        CATCH_REQUIRE(std::all_of(v.begin(), v.end(), [](const uint64_t& v) {
-            return v == 2;
-        }));
+            CATCH_REQUIRE(std::all_of(v.begin(), v.end(), [](const uint64_t& v) {
+                return v == 2;
+            }));
+        }
+
+        /////
+        ///// NativeThreadPool
+        /////
+
+        CATCH_SECTION("NativeThreadPool") {
+            auto pool = svs::threads::NativeThreadPool(num_threads);
+            start_time = std::chrono::steady_clock::now();
+            svs::threads::parallel_for(pool, svs::threads::StaticPartition{v.size()}, f);
+            stop_time = std::chrono::steady_clock::now();
+            time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
+            std::cout << "NativeThreadPool: " << time_seconds << " seconds" << std::endl;
+
+            start_time = std::chrono::steady_clock::now();
+            svs::threads::parallel_for(pool, svs::threads::StaticPartition{v.size()}, f);
+            stop_time = std::chrono::steady_clock::now();
+            time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
+            std::cout << "NativeThreadPool: " << time_seconds << " seconds" << std::endl;
+
+            CATCH_REQUIRE(std::all_of(v.begin(), v.end(), [](const uint64_t& v) {
+                return v == 2;
+            }));
+        }
+
+        /////
+        ///// CppAsyncThreadPool
+        /////
+        CATCH_SECTION("CppAsyncThreadPool") {
+            auto pool = svs::threads::CppAsyncThreadPool(num_threads);
+            start_time = std::chrono::steady_clock::now();
+            svs::threads::parallel_for(pool, svs::threads::StaticPartition{v.size()}, f);
+            stop_time = std::chrono::steady_clock::now();
+            time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
+            std::cout << "CppAsyncThreadPool: " << time_seconds << " seconds" << std::endl;
+
+            start_time = std::chrono::steady_clock::now();
+            svs::threads::parallel_for(pool, svs::threads::StaticPartition{v.size()}, f);
+            stop_time = std::chrono::steady_clock::now();
+            time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
+            std::cout << "CppAsyncThreadPool: " << time_seconds << " seconds" << std::endl;
+
+            CATCH_REQUIRE(std::all_of(v.begin(), v.end(), [](const uint64_t& v) {
+                return v == 2;
+            }));
+        }
+
+        /////
+        ///// QueueThreadPool
+        /////
+        CATCH_SECTION("QueueThreadPool") {
+            auto pool = svs::threads::QueueThreadPoolWrapper(num_threads);
+            start_time = std::chrono::steady_clock::now();
+            svs::threads::parallel_for(pool, svs::threads::StaticPartition{v.size()}, f);
+            stop_time = std::chrono::steady_clock::now();
+            time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
+            std::cout << "QueueThreadPool: " << time_seconds << " seconds" << std::endl;
+
+            start_time = std::chrono::steady_clock::now();
+            svs::threads::parallel_for(pool, svs::threads::StaticPartition{v.size()}, f);
+            stop_time = std::chrono::steady_clock::now();
+            time_seconds = std::chrono::duration<float>(stop_time - start_time).count();
+            std::cout << "QueueThreadPool: " << time_seconds << " seconds" << std::endl;
+
+            CATCH_REQUIRE(std::all_of(v.begin(), v.end(), [](const uint64_t& v) {
+                return v == 2;
+            }));
+        }
     }
 }

--- a/tests/svs/lib/threads/thunks.cpp
+++ b/tests/svs/lib/threads/thunks.cpp
@@ -36,24 +36,15 @@ CATCH_TEST_CASE("Thread Thunks", "[core][threads]") {
     std::vector<size_t> u{};
     CATCH_SECTION("Default Thunk") {
         auto f = [&v](uint64_t i) { v.push_back(i); };
-        auto wrapped = threads::thunks::wrap(threads::ThreadCount{1}, f);
-        auto f_ref = threads::FunctionRef(wrapped);
-        CATCH_REQUIRE(f_ref.arg == &wrapped);
-        CATCH_REQUIRE(v.empty());
-        f_ref(1);
-        f_ref(2);
-        f_ref(3);
-        CATCH_REQUIRE(v.size() == 3);
-        CATCH_REQUIRE(v.at(0) == 1);
-        CATCH_REQUIRE(v.at(1) == 2);
-        CATCH_REQUIRE(v.at(2) == 3);
+        std::function<void(size_t)> wrapped = threads::thunks::wrap(threads::ThreadCount{1}, f);
 
-        threads::ThreadFunctionRef g{f_ref, 10};
-        CATCH_REQUIRE(g.fn.arg == f_ref.arg);
-        CATCH_REQUIRE(g.fn.fn == f_ref.fn);
+        threads::ThreadFunctionRef g{&wrapped, 10};
+        CATCH_REQUIRE(g.fn == &wrapped);
         g();
-        CATCH_REQUIRE(v.size() == 4);
-        CATCH_REQUIRE(v.at(3) == 10);
+        g();
+        g();
+        CATCH_REQUIRE(v.size() == 3);
+        CATCH_REQUIRE(v.at(2) == 10);
     }
 
     CATCH_SECTION("Static Index Partition") {
@@ -69,9 +60,8 @@ CATCH_TEST_CASE("Thread Thunks", "[core][threads]") {
         // |       |   |       |   |   |   |   |
         // +-------+   +-------+   +---+   +---+
         //    T0          T1         T2      T3
-        auto thunk =
+        std::function<void(size_t)> wrapped =
             threads::thunks::wrap(threads::ThreadCount{4}, f, threads::StaticPartition{10});
-        auto wrapped = threads::FunctionRef(thunk);
 
         CATCH_REQUIRE(v.empty());
         CATCH_REQUIRE(u.empty());
@@ -144,8 +134,7 @@ CATCH_TEST_CASE("Thread Thunks", "[core][threads]") {
             }
         };
 
-        auto thunk = threads::thunks::wrap(threads::ThreadCount{4}, f, partition);
-        auto wrapped = threads::FunctionRef(thunk);
+        std::function<void(size_t)> wrapped = threads::thunks::wrap(threads::ThreadCount{4}, f, partition);
 
         CATCH_REQUIRE(v.empty());
         CATCH_REQUIRE(u.empty());
@@ -219,10 +208,9 @@ CATCH_TEST_CASE("Thread Thunks", "[core][threads]") {
         // |       |   |       |   |       |   |
         // +-------+   +-------+   +-------+   |
         //    1st         2nd         3rd     4th
-        auto thunk = threads::thunks::wrap(
+        std::function<void(size_t)> wrapped = threads::thunks::wrap(
             threads::ThreadCount{4}, f, threads::DynamicPartition{10, 3}
         );
-        auto wrapped = threads::FunctionRef(thunk);
 
         CATCH_REQUIRE(v.empty());
         CATCH_REQUIRE(u.empty());

--- a/tests/svs/lib/threads/thunks.cpp
+++ b/tests/svs/lib/threads/thunks.cpp
@@ -36,7 +36,8 @@ CATCH_TEST_CASE("Thread Thunks", "[core][threads]") {
     std::vector<size_t> u{};
     CATCH_SECTION("Default Thunk") {
         auto f = [&v](uint64_t i) { v.push_back(i); };
-        std::function<void(size_t)> wrapped = threads::thunks::wrap(threads::ThreadCount{1}, f);
+        std::function<void(size_t)> wrapped =
+            threads::thunks::wrap(threads::ThreadCount{1}, f);
 
         threads::ThreadFunctionRef g{&wrapped, 10};
         CATCH_REQUIRE(g.fn == &wrapped);
@@ -134,7 +135,8 @@ CATCH_TEST_CASE("Thread Thunks", "[core][threads]") {
             }
         };
 
-        std::function<void(size_t)> wrapped = threads::thunks::wrap(threads::ThreadCount{4}, f, partition);
+        std::function<void(size_t)> wrapped =
+            threads::thunks::wrap(threads::ThreadCount{4}, f, partition);
 
         CATCH_REQUIRE(v.empty());
         CATCH_REQUIRE(u.empty());

--- a/utils/characterization/consolidate.cpp
+++ b/utils/characterization/consolidate.cpp
@@ -68,7 +68,7 @@ int svs_main(std::vector<std::string> args) {
         indices_to_delete.insert(distribution(rng));
     }
 
-    auto threadpool = svs::threads::NativeThreadPool(nthreads);
+    auto threadpool = svs::threads::DefaultThreadPool(nthreads);
 
     // Now, perform the deletion.
     std::cout << "Consolidating Graph" << std::endl;


### PR DESCRIPTION
This PR introduces support for custom thread pool. By allowing users to define and manage their own thread pools, we can provide greater flexibility and control over the multithreaded execution. This is particularly useful for users that need to integrate with existing thread management frameworks.

APIs (Applicable for Every Indices):
```c++
auto index  = assemble(..., num_threads);                       // Create a default thread pool with num_threads
auto index2 = assemble(..., CustomThreadPool(num_threads));     // Create a custom thread pool with num_threads
auto index3 = build(..., num_threads);                          // Create a default thread pool with num_threads
auto index4 = build(..., CustomThreadPool(num_threads));        // Create a custom thread pool with num_threads
index4.set_threadpool(CustomThreadPool2(num_threads));          // Destroy the original thread pool and set to the new thread pool during runtime

auto& threadpool_handle = index4.get_threadpool_handle();       // Get the thread pool handle
auto& threadpool = threadpool_handle.get<CustomThreadPool3>();  // Get the thread pool with the right type

size_t num_threads = index4.get_num_threads();                  // Get the number of threads used in the thread pool
```


There are two implementation requirements for a custom thread pool to work on SVS: 
1) `size()`: This method should return the number of threads in the thread pool.
2) `parallel_for(std::function<void(size_t)> f, size_t n)`: This method should execute the tasks. Here, `f(i)` represents a task on the `i^th` partition, and `n` represents the number of partitions that need to be executed.

Example:
```cpp
class CustomThreadPool {

  CustomThreadPool(size_t num_threads): num_threads_{num_threads} {
  }

  // SVS requirement #1
  size_t size() {
    // return the number of workers
  }

  // SVS requirement #2
  void parallel_for(std::function<void(size_t)> f, size_t n) {
    // execute f(0), f(1), ..., f(n-1) tasks
  }
  size_t num_threads_;
};
```

Changes:

1. Remove `set_num_threads()` at C++ level to eliminate the need of a resizable thread pool. For the python binding, we bind `index.num_threads = num_threads` to `index.set_threadpool(svs::threads::DefaultThreadPool(num_threads))`. This implementation will destroy the original thread pool and create the new one with the desired `num_threads`. The overhead will increase; however, this call should be made very rarely.
2. Modify some testcases and replace `set_num_threads()` with `set_threadpool(svs::threads::DefaultThreadPool(num_threads)` due to the removal of `set_num_threads()`.
3. Remove thread pool reference part in Flat. In original version, Flat can either own the thread pool or take a reference of the thread pool. This is inconsistent with other indices. Also, the reference can be done by implementing a thread pool reference wrapper. For example:
```cpp
class CustomThreadPoolReferenceWrapper {

  CustomThreadPoolReferenceWrapper(CustomThreadPool& threadpool): threadpool_{threadpool} {
  }

  // SVS requirement #1
  size_t size() {
    return threadpool_.size();
  }

  // SVS requirement #2
  void parallel_for(std::function<void(size_t)> f, size_t n) {
     threadpool_.run(std::move(f), n);
  }
  CustomThreadPool& threadpool;
};
```
Owing this thread pool reference wrapper is essentially the same as taking a reference of the thread pool.

4. Support custom thread pool in kmeans.
5. Support custom thread pool in `ReferenceDataset`.
6. Add `CppAsyncThreadPool` and `QueueThreadPool` for both example and testing
7. Add `ThreadPoolReferenceWrapper` as a utility reference wrapper.
8. Replace the name `run` with `parallel_for`. `parallel_for` is more meaningful and precise.
9. Replace `FunctionRef` with `std::function<void(size_t)>`.  As we expose `parallel_for` to users, `std::function<void(size_t)>` is more general.  I did not observe a significant increase in binary size, and the change does not impact performance.