### PR TITLE
Add a new thread pool that switches between single- and multi- threaded execution

### DIFF
--- a/tests/integration/exhaustive.cpp
+++ b/tests/integration/exhaustive.cpp
@@ -327,6 +327,13 @@ CATCH_TEST_CASE("Flat Orchestrator Search", "[integration][exhaustive][orchestra
             svs::threads::QueueThreadPoolWrapper>(
             index, queries, test_dataset::groundtruth_cosine()
         );
+        test_flat<
+            decltype(index),
+            decltype(queries),
+            decltype(test_dataset::groundtruth_cosine()),
+            svs::threads::SwitchNativeThreadPool>(
+            index, queries, test_dataset::groundtruth_cosine()
+        );
     }
 
     CATCH_SECTION("Cosine With Different Thread Pools From Data") {
@@ -357,6 +364,13 @@ CATCH_TEST_CASE("Flat Orchestrator Search", "[integration][exhaustive][orchestra
             decltype(queries),
             decltype(test_dataset::groundtruth_cosine()),
             svs::threads::DefaultThreadPool>(
+            index, queries, test_dataset::groundtruth_cosine()
+        );
+        test_flat<
+            decltype(index),
+            decltype(queries),
+            decltype(test_dataset::groundtruth_cosine()),
+            svs::threads::SwitchNativeThreadPool>(
             index, queries, test_dataset::groundtruth_cosine()
         );
     }

--- a/tests/integration/vamana/index_search.cpp
+++ b/tests/integration/vamana/index_search.cpp
@@ -339,5 +339,10 @@ CATCH_TEST_CASE("Uncompressed Vamana Search", "[integration][search][vamana]") {
         run_tests<svs::threads::CppAsyncThreadPool>(
             index, queries, groundtruth, expected_results.config_and_recall_
         );
+
+        index.set_threadpool(svs::threads::SwitchNativeThreadPool(2));
+        run_tests<svs::threads::SwitchNativeThreadPool>(
+            index, queries, groundtruth, expected_results.config_and_recall_
+        );
     }
 }


### PR DESCRIPTION
 A thread pool that dynamically switches between single-threaded and multi-threaded execution.
- If `n == 1`, the task will be executed on the main thread without any locking mechanism that exists in `NativeThreadPool`.
- For `n > 1`, the tasks will be delegated to the internal `NativeThreadPool` for parallel execution.