### PR TITLE
add reuse_empty flag and update heuristics used in vamana construct

### DIFF
--- a/bindings/python/src/dynamic_vamana.cpp
+++ b/bindings/python/src/dynamic_vamana.cpp
@@ -92,7 +92,8 @@ template <typename ElementType>
 void add_points(
     svs::DynamicVamana& index,
     const py_contiguous_array_t<ElementType>& py_data,
-    const py_contiguous_array_t<size_t>& ids
+    const py_contiguous_array_t<size_t>& ids,
+    bool reuse_empty = false
 ) {
     if (py_data.ndim() != 2) {
         throw ANNEXCEPTION("Expected points to have 2 dimensions!");
@@ -105,7 +106,7 @@ void add_points(
             "Expected IDs to be the same length as the number of rows in points!"
         );
     }
-    index.add_points(data_view(py_data), std::span(ids.data(), ids.size()));
+    index.add_points(data_view(py_data), std::span(ids.data(), ids.size()), reuse_empty);
 }
 
 const char* ADD_POINTS_DOCSTRING = R"(
@@ -117,6 +118,8 @@ Args:
         the index.
     ids: Vector of ids to assign to each row in ``points``. Must have the same number of
         elements as ``points`` has rows.
+    reuse_empty: A flag that determines whether to reuse empty slots that may exist after deletion and consolidation.
+    If true, the scan starts from the beginning of the data to reuse empty slots.
 
 Furthermore, all entries in ``ids`` must be unique and not already exist in the index.
 If either of these does not hold, an exception will be thrown without mutating the
@@ -130,6 +133,7 @@ void add_points_specialization(py::class_<svs::DynamicVamana>& index) {
         &add_points<ElementType>,
         py::arg("points"),
         py::arg("ids"),
+        py::arg("reuse_empty") = false,
         ADD_POINTS_DOCSTRING
     );
 }

--- a/bindings/python/src/dynamic_vamana.cpp
+++ b/bindings/python/src/dynamic_vamana.cpp
@@ -118,12 +118,16 @@ Args:
         the index.
     ids: Vector of ids to assign to each row in ``points``. Must have the same number of
         elements as ``points`` has rows.
-    reuse_empty: A flag that determines whether to reuse empty slots that may exist after deletion and consolidation.
-    If true, the scan starts from the beginning of the data to reuse empty slots.
+    reuse_empty: A flag that determines whether to reuse empty entries that may exist after deletion and consolidation. When enabled,
+    scan from the beginning to find and fill these empty entries when adding new points.
 
 Furthermore, all entries in ``ids`` must be unique and not already exist in the index.
 If either of these does not hold, an exception will be thrown without mutating the
 underlying index.
+
+When ``delete_entries`` is called, a soft deletion is performed, marking the entries as ``deleted``.
+The state of these deleted entries becomes ``empty`` as the user calls ``consolidate``.
+When ``add_points`` is called with the ``reuse_empty`` flag enabled, the memory is scanned from the beginning to locate and fill these empty entries with new points.
 )";
 
 template <typename ElementType>

--- a/bindings/python/src/dynamic_vamana.cpp
+++ b/bindings/python/src/dynamic_vamana.cpp
@@ -126,7 +126,7 @@ If either of these does not hold, an exception will be thrown without mutating t
 underlying index.
 
 When ``delete_entries`` is called, a soft deletion is performed, marking the entries as ``deleted``.
-The state of these deleted entries becomes ``empty`` as the user calls ``consolidate``.
+When ``consolidate`` is called, the state of these deleted entries becomes ``empty``.
 When ``add_points`` is called with the ``reuse_empty`` flag enabled, the memory is scanned from the beginning to locate and fill these empty entries with new points.
 )";
 

--- a/include/svs/index/vamana/dynamic_index.h
+++ b/include/svs/index/vamana/dynamic_index.h
@@ -580,8 +580,8 @@ class MutableVamanaIndex {
     /// @brief Add the points with the given external IDs to the dataset.
     //
     /// When `delete_entries` is called, a soft deletion is performed, marking the entries
-    /// as `deleted`. The state of these deleted entries becomes `empty` as the user call
-    /// `consolidate`. When `add_points` is called with the `reuse_empty` flag enabled, the
+    /// as `deleted`. When `consolidate` is called, the state of these deleted entries becomes `empty`.
+    /// When `add_points` is called with the `reuse_empty` flag enabled, the
     /// memory is scanned from the beginning to locate and fill these empty entries with new
     /// points.
     ///

--- a/include/svs/index/vamana/vamana_build.h
+++ b/include/svs/index/vamana/vamana_build.h
@@ -220,7 +220,7 @@ class VamanaBuilder {
             size_t{40}, lib::div_round_up(num_nodes, lib::narrow_cast<size_t>(64 * 64))
         );
 
-        // If num_batches is greater than num_nodes (num_batches will be 40), set
+        // If num_batches is greater than num_nodes, set
         // num_batches to num_nodes to avoid unnecessary iterations.
         if (num_batches > num_nodes) {
             num_batches = num_nodes;

--- a/include/svs/index/vamana/vamana_build.h
+++ b/include/svs/index/vamana/vamana_build.h
@@ -219,6 +219,13 @@ class VamanaBuilder {
         size_t num_batches = std::max(
             size_t{40}, lib::div_round_up(num_nodes, lib::narrow_cast<size_t>(64 * 64))
         );
+
+        // If num_batches is greater than num_nodes (num_batches will be 40), set
+        // num_batches to num_nodes to avoid unnecessary iterations.
+        if (num_batches > num_nodes) {
+            num_batches = num_nodes;
+        }
+
         size_t batchsize = lib::div_round_up(num_nodes, num_batches);
         std::vector entry_points{entry_point};
 

--- a/include/svs/orchestrators/dynamic_vamana.h
+++ b/include/svs/orchestrators/dynamic_vamana.h
@@ -33,7 +33,11 @@ class DynamicVamanaInterface : public VamanaInterface {
   public:
     // TODO: For now - only accept floating point entries.
     virtual void add_points(
-        const float* data, size_t dim0, size_t dim1, std::span<const size_t> ids
+        const float* data,
+        size_t dim0,
+        size_t dim1,
+        std::span<const size_t> ids,
+        bool reuse_empty = false
     ) = 0;
 
     virtual void delete_points(std::span<const size_t> ids) = 0;
@@ -60,10 +64,14 @@ class DynamicVamanaImpl : public VamanaImpl<QueryTypes, Impl, DynamicVamanaInter
 
     // Implement the interface.
     void add_points(
-        const float* data, size_t dim0, size_t dim1, std::span<const size_t> ids
+        const float* data,
+        size_t dim0,
+        size_t dim1,
+        std::span<const size_t> ids,
+        bool reuse_empty = false
     ) override {
         auto points = data::ConstSimpleDataView<float>(data, dim0, dim1);
-        impl().add_points(points, ids);
+        impl().add_points(points, ids, reuse_empty);
     }
 
     void delete_points(std::span<const size_t> ids) override { impl().delete_entries(ids); }
@@ -148,9 +156,14 @@ class DynamicVamana : public manager::IndexManager<DynamicVamanaInterface> {
         return *this;
     }
 
-    DynamicVamana&
-    add_points(data::ConstSimpleDataView<float> points, std::span<const size_t> ids) {
-        impl_->add_points(points.data(), points.size(), points.dimensions(), ids);
+    DynamicVamana& add_points(
+        data::ConstSimpleDataView<float> points,
+        std::span<const size_t> ids,
+        bool reuse_empty = false
+    ) {
+        impl_->add_points(
+            points.data(), points.size(), points.dimensions(), ids, reuse_empty
+        );
         return *this;
     }
 


### PR DESCRIPTION
This PR includes two updates:

1. Introduces the `reuse_empty` flag, allowing users to decide whether to reuse empty entries that may exist after deletion and consolidation. Previously, SVS always scanned from the beginning of the memory to find empty entries, which could negatively impact performance. This change gives users the flexibility to optimize performance based on their specific needs. By default, the `reuse_empty` flag is set to false to optimize performance.
2. Updates the heuristics used in the Vamana construct. This addresses the issue where, even with fewer than 40 points, SVS would still iterate 40 times, causing unnecessary overhead. The new heuristics aim to reduce this inefficiency.