### PR TITLE
Revert accidently changed BuildJob version for benchmarking.

### DIFF
--- a/benchmark/include/svs-benchmark/vamana/build.h
+++ b/benchmark/include/svs-benchmark/vamana/build.h
@@ -307,7 +307,7 @@ struct BuildJob : public BuildJobBase {
     //    - B. Align more closely with the `SearchJob`.
     //    Added an argument "save_directory" to allow built indexes to be saved after
     //    building.
-    static constexpr svs::lib::Version save_version = svs::lib::Version(0, 0, 5);
+    static constexpr svs::lib::Version save_version = svs::lib::Version(0, 0, 4);
     static constexpr std::string_view serialization_schema = "benchmark_vamana_build_job";
 
     // Save the BuildJob to a TOML table.


### PR DESCRIPTION
Revert the version change made earlier (here https://github.com/intel/ScalableVectorSearch/commit/427c30a302c94f2899404082bddd3d9a0de91ae2#diff-1ac47ac6ee0c9ca6f8bf0cb1ffde54b91aef322816eddf3680e9ae99dca1ef2bL294)
This is an internal version for build jobs used for benchmarking and not related to the package/library version.