### PR TITLE
feat: add remaining Float16 specializations for simd calculation

### DIFF
--- a/include/svs/core/distance/cosine.h
+++ b/include/svs/core/distance/cosine.h
@@ -306,9 +306,26 @@ template <size_t N> struct CosineSimilarityImpl<N, float, int8_t> {
 template <size_t N> struct CosineSimilarityImpl<N, float, Float16> {
     SVS_NOINLINE static float
     compute(const float* a, const Float16* b, float a_norm, lib::MaybeStatic<N> length) {
-        auto [sum, norm] = simd::generic_simd_op(CosineFloatOp<16>(), a, b, length);
+        auto [sum, norm] = simd::generic_simd_op(CosineFloatOp<16>{}, a, b, length);
         return sum / (std::sqrt(norm) * a_norm);
     }
 };
+
+template <size_t N> struct CosineSimilarityImpl<N, Float16, float> {
+    SVS_NOINLINE static float
+    compute(const Float16* a, const float* b, float a_norm, lib::MaybeStatic<N> length) {
+        auto [sum, norm] = simd::generic_simd_op(CosineFloatOp<16>{}, a, b, length);
+        return sum / (std::sqrt(norm) * a_norm);
+    }
+};
+
+template <size_t N> struct CosineSimilarityImpl<N, Float16, Float16> {
+    SVS_NOINLINE static float
+    compute(const Float16* a, const Float16* b, float a_norm, lib::MaybeStatic<N> length) {
+        auto [sum, norm] = simd::generic_simd_op(CosineFloatOp<16>{}, a, b, length);
+        return sum / (std::sqrt(norm) * a_norm);
+    }
+};
+
 #endif
 } // namespace svs::distance

--- a/include/svs/index/inverted/common.h
+++ b/include/svs/index/inverted/common.h
@@ -40,14 +40,12 @@ template <typename T> inline T bound_with(T nearest, T epsilon, svs::DistanceL2)
 }
 
 template <typename T> inline T bound_with(T nearest, T epsilon, svs::DistanceIP) {
-    // TODO: What do we do if the best match is simply bad?
     assert(nearest > 0.0f);
     return nearest / (1 + epsilon);
 }
 
 template <typename T>
 inline T bound_with(T nearest, T epsilon, svs::DistanceCosineSimilarity) {
-    // TODO: This is just copy/paste from DistanceIP - is it correct?
     assert(nearest > 0.0f);
     return nearest / (1 + epsilon);
 }

--- a/include/svs/index/inverted/common.h
+++ b/include/svs/index/inverted/common.h
@@ -45,4 +45,11 @@ template <typename T> inline T bound_with(T nearest, T epsilon, svs::DistanceIP)
     return nearest / (1 + epsilon);
 }
 
+template <typename T>
+inline T bound_with(T nearest, T epsilon, svs::DistanceCosineSimilarity) {
+    // TODO: This is just copy/paste from DistanceIP - is it correct?
+    assert(nearest > 0.0f);
+    return nearest / (1 + epsilon);
+}
+
 } // namespace svs::index::inverted


### PR DESCRIPTION
This PR adds the remaining `Float16` specializations for `CosineSimilarityImpl`, resulting in SIMD ops being used instead of the generic reference implementation in some of the test cases.