### PR TITLE
fix: add alias for IntelLLVM compiler

### DIFF
--- a/bindings/python/include/svs/python/manager.h
+++ b/bindings/python/include/svs/python/manager.h
@@ -119,7 +119,9 @@ reconstruct(Index& index, py_contiguous_array_t<uint64_t> ids) {
     auto destination = py_contiguous_array_t<float>({num_ids, data_dims});
     index.reconstruct_at(
         mutable_data_view(destination),
-        std::span<const uint64_t>(ids.template mutable_unchecked().mutable_data(), num_ids)
+        std::span<const uint64_t>(
+            ids.template mutable_unchecked<-1>().mutable_data(), num_ids
+        )
     );
 
     // Reshape the destination to have the same shape as the original IDs (plus the extra

--- a/bindings/python/microarch.py
+++ b/bindings/python/microarch.py
@@ -85,7 +85,7 @@ def resolve_compiler(name: str):
     aliases = {
         "GNU": "gcc",
         "Clang": "clang",
-        "IntelLLVM": "intel"
+        "IntelLLVM": "oneapi",
     }
     return aliases.get(name, name)
 

--- a/bindings/python/microarch.py
+++ b/bindings/python/microarch.py
@@ -85,6 +85,7 @@ def resolve_compiler(name: str):
     aliases = {
         "GNU": "gcc",
         "Clang": "clang",
+        "IntelLLVM": "intel"
     }
     return aliases.get(name, name)
 


### PR DESCRIPTION
This adds the correct `archspec` name for `CMake` `IntelLLVM`.