### PR TITLE
Solve batch iterator reranking issue

### DIFF
--- a/include/svs/index/vamana/iterator.h
+++ b/include/svs/index/vamana/iterator.h
@@ -334,13 +334,16 @@ class BatchIterator {
                                            ) {
             auto search_closure =
                 [&](const auto& query, const auto& accessor, auto& d, auto& buffer) {
-                    constexpr vamana::extensions::UsesReranking<std::remove_const_t<decltype(data)>> uses_reranking{};
-                    if constexpr(uses_reranking()) {
+                    constexpr vamana::extensions::UsesReranking<
+                        std::remove_const_t<std::remove_reference_t<decltype(data)>>>
+                        uses_reranking{};
+                    if constexpr (uses_reranking()) {
                         // recompute search buffer using only primary dataset
                         for (size_t j = 0, jmax = buffer.size(); j < jmax; ++j) {
                             auto& neighbor = buffer[j];
                             auto id = neighbor.id();
-                            auto new_distance = distance::compute(d, query, data.get_primary(id));
+                            auto new_distance =
+                                distance::compute(d, query, data.get_primary(id));
                             neighbor.set_distance(new_distance);
                         }
                         buffer.sort();

--- a/include/svs/index/vamana/iterator.h
+++ b/include/svs/index/vamana/iterator.h
@@ -338,6 +338,7 @@ class BatchIterator {
                         std::remove_const_t<std::remove_reference_t<decltype(data)>>>
                         uses_reranking{};
                     if constexpr (uses_reranking()) {
+                        distance::maybe_fix_argument(d, query);
                         // recompute search buffer using only primary dataset
                         for (size_t j = 0, jmax = buffer.size(); j < jmax; ++j) {
                             auto& neighbor = buffer[j];

--- a/include/svs/index/vamana/iterator.h
+++ b/include/svs/index/vamana/iterator.h
@@ -334,6 +334,18 @@ class BatchIterator {
                                            ) {
             auto search_closure =
                 [&](const auto& query, const auto& accessor, auto& d, auto& buffer) {
+                    constexpr vamana::extensions::UsesReranking<std::remove_const_t<decltype(data)>> uses_reranking{};
+                    if constexpr(uses_reranking()) {
+                        // recompute search buffer using only primary dataset
+                        for (size_t j = 0, jmax = buffer.size(); j < jmax; ++j) {
+                            auto& neighbor = buffer[j];
+                            auto id = neighbor.id();
+                            auto new_distance = distance::compute(d, query, data.get_primary(id));
+                            neighbor.set_distance(new_distance);
+                        }
+                        buffer.sort();
+                    }
+
                     vamana::greedy_search(
                         graph,
                         data,


### PR DESCRIPTION
This PR addresses the reranking issue in the batch iterator. When the dataset requires reranking after a search, it is necessary to restore the distances using the primary dataset before proceeding to search for the next batch.  Failing to do so may result in the search buffer being mixed with both reranking results and primary dataset results.