### PR TITLE
Fix svs::lib::allocator

### DIFF
--- a/include/svs/lib/memory.h
+++ b/include/svs/lib/memory.h
@@ -61,7 +61,7 @@ template <typename T> struct Allocator {
     }
 
     constexpr void deallocate(value_type* ptr, size_t count) noexcept {
-        ::operator delete(ptr, count);
+        ::operator delete(ptr, count, std::align_val_t(alignof(T)));
     }
 
     // Intercept zero-argument construction to do default initialization.


### PR DESCRIPTION
This PR fixes allocate/deallocate mismatch to resolve Valgrind memory checks errors.