### PR TITLE
Solve invalid memory read issue in find_nearest

### DIFF
--- a/include/svs/core/kmeans.h
+++ b/include/svs/core/kmeans.h
@@ -45,6 +45,13 @@ Neighbor<size_t> find_nearest(const Query& query, const Data& data) {
         auto d = distance::compute(f, query, data.get_datum(i));
         nearest = std::min(nearest, Neighbor<size_t>(i, d));
     }
+
+    // If the distance is infinity and the id remains unchanged from sentinel_v,
+    // reset to the first index to return to the exsiting neighbor.
+    if (nearest.id() == type_traits::sentinel_v<Neighbor<size_t>, std::less<>>.id() &&
+        data.size() > 0) {
+        nearest = Neighbor<size_t>(0, nearest.distance());
+    }
     return nearest;
 }
 

--- a/include/svs/core/kmeans.h
+++ b/include/svs/core/kmeans.h
@@ -46,10 +46,9 @@ Neighbor<size_t> find_nearest(const Query& query, const Data& data) {
         nearest = std::min(nearest, Neighbor<size_t>(i, d));
     }
 
-    // If the distance is infinity and the id remains unchanged from sentinel_v,
+    // The case where the distance is infinity and the id remains unchanged from sentinel_v,
     // reset to the first index to return to the exsiting neighbor.
-    if (nearest.id() == type_traits::sentinel_v<Neighbor<size_t>, std::less<>>.id() &&
-        data.size() > 0) {
+    if (nearest.id() >= data.size()) {
         nearest = Neighbor<size_t>(0, nearest.distance());
     }
     return nearest;

--- a/include/svs/lib/neighbor.h
+++ b/include/svs/lib/neighbor.h
@@ -157,7 +157,7 @@ template <typename Cmp> class TotalOrder {
 namespace type_traits {
 template <typename Idx, typename Cmp> struct Sentinel<Neighbor<Idx>, Cmp> {
     static constexpr Neighbor<Idx> value =
-        Neighbor<Idx>{0, sentinel_v<float, Cmp>};
+        Neighbor<Idx>{std::numeric_limits<Idx>::max(), sentinel_v<float, Cmp>};
 };
 } // namespace type_traits
 

--- a/include/svs/lib/neighbor.h
+++ b/include/svs/lib/neighbor.h
@@ -157,7 +157,7 @@ template <typename Cmp> class TotalOrder {
 namespace type_traits {
 template <typename Idx, typename Cmp> struct Sentinel<Neighbor<Idx>, Cmp> {
     static constexpr Neighbor<Idx> value =
-        Neighbor<Idx>{std::numeric_limits<Idx>::max(), sentinel_v<float, Cmp>};
+        Neighbor<Idx>{0, sentinel_v<float, Cmp>};
 };
 } // namespace type_traits
 


### PR DESCRIPTION
This PR addresses the corner cases where neighbor id may be [max](https://github.com/intel/ScalableVectorSearch/blob/72633231807d46ff59f651916858fa0ed6ba3ee4/include/svs/lib/neighbor.h#L160) when distance is infinity. In such scenarios, the system could return a neighbor with the maximum ID, leading to an invalid memory read. To resolve this, the PR modifies the behavior to reset the ID to the first index, ensuring a valid existing neighbor is returned.