### PR TITLE
Update eve to the last version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,31 +16,6 @@ cmake_minimum_required(VERSION 3.21)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
-# Check if we are on Linux, AArch64, and using GCC.
-# This needs to happen *before* project() so flags/definitions are set early.
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
-   CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64" AND
-   (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR NOT CMAKE_CXX_COMPILER_ID) # Check ID or if not yet set
-  )
-    message(STATUS "ARM Linux GCC detected: Adding -march=armv8-a and defining EVE_SUPPORTS_NEON for EVE compatibility.")
-
-    # 1. Ensure compiler targets NEON-capable arch
-    set(ARM_GCC_ARCH_FLAG "-march=armv8-a")
-    # Check if already set by environment/toolchain to avoid duplication if needed
-    if(NOT CMAKE_CXX_FLAGS MATCHES "-march=")
-       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARM_GCC_ARCH_FLAG}" CACHE STRING "CXX Flags" FORCE)
-    endif()
-     if(NOT CMAKE_C_FLAGS MATCHES "-march=")
-       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ARM_GCC_ARCH_FLAG}" CACHE STRING "C Flags" FORCE)
-    endif()
-
-    # 2. Force EVE to recognize NEON support by defining its internal macro
-    #    This should influence EVE's headers during its own configuration via FetchContent.
-    #    Using add_compile_definitions ensures it's passed via -D to the compiler.
-    add_compile_definitions(EVE_SUPPORTS_NEON)
-
-endif()
-
 project(svs
     LANGUAGES CXX
     # The version is tested in the files:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,23 @@ cmake_minimum_required(VERSION 3.21)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
+# Check if we are on Linux, AArch64, and using GCC.
+# This needs to happen *before* project() so flags are set early.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
+   CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64" AND
+   (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR NOT CMAKE_CXX_COMPILER_ID) # Check ID or if not yet set
+   )
+    message(STATUS "ARM Linux GCC detected: Appending flags for EVE compatibility (-march=armv8-a -D__ARM_NEON -DEVE_ARM_64)")
+
+    # Append flags directly to the cache variables. This influences compiler checks.
+    # Using CACHE STRING ... FORCE ensures they are set and override previous cache values if necessary.
+    # We add -march to ensure NEON is enabled by the compiler itself.
+    # We add -D__ARM_NEON because EVE checks for it.
+    # We add -DEVE_ARM_64 as it seems to be an internal EVE check.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv8-a -D__ARM_NEON -DEVE_ARM_64" CACHE STRING "CXX Flags" FORCE)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8-a -D__ARM_NEON -DEVE_ARM_64" CACHE STRING "C Flags" FORCE)
+endif()
+
 project(svs
     LANGUAGES CXX
     # The version is tested in the files:
@@ -60,21 +77,6 @@ target_compile_options(
     "-DSVS_VERSION_MINOR=${SVS_VERSION_MINOR}"
     "-DSVS_VERSION_PATCH=${SVS_VERSION_PATCH}"
 )
-
-# Explicitly define ARM NEON macros for GCC on AArch64
-# This helps EVE's internal detection mechanism which seems problematic with GCC.
-# We define __ARM_NEON (standard macro) and EVE_ARM_64 (EVE specific).
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
-   CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64" AND
-   (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
-    add_compile_definitions(__ARM_NEON EVE_ARM_64)
-
-    if(NOT CMAKE_CXX_FLAGS MATCHES "-march=")
-       string(APPEND CMAKE_CXX_FLAGS_INIT " -march=armv8-a")
-       string(APPEND CMAKE_C_FLAGS_INIT " -march=armv8-a")
-    endif()
-
-endif()
 
 #####
 ##### Options and extra build steps

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,20 +17,28 @@ cmake_minimum_required(VERSION 3.21)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 # Check if we are on Linux, AArch64, and using GCC.
-# This needs to happen *before* project() so flags are set early.
+# This needs to happen *before* project() so flags/definitions are set early.
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
    CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64" AND
    (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR NOT CMAKE_CXX_COMPILER_ID) # Check ID or if not yet set
-   )
-    message(STATUS "ARM Linux GCC detected: Appending flags for EVE compatibility (-march=armv8-a -D__ARM_NEON -DEVE_ARM_64)")
+  )
+    message(STATUS "ARM Linux GCC detected: Adding -march=armv8-a and defining EVE_SUPPORTS_NEON for EVE compatibility.")
 
-    # Append flags directly to the cache variables. This influences compiler checks.
-    # Using CACHE STRING ... FORCE ensures they are set and override previous cache values if necessary.
-    # We add -march to ensure NEON is enabled by the compiler itself.
-    # We add -D__ARM_NEON because EVE checks for it.
-    # We add -DEVE_ARM_64 as it seems to be an internal EVE check.
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv8-a -D__ARM_NEON -DEVE_ARM_64" CACHE STRING "CXX Flags" FORCE)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8-a -D__ARM_NEON -DEVE_ARM_64" CACHE STRING "C Flags" FORCE)
+    # 1. Ensure compiler targets NEON-capable arch
+    set(ARM_GCC_ARCH_FLAG "-march=armv8-a")
+    # Check if already set by environment/toolchain to avoid duplication if needed
+    if(NOT CMAKE_CXX_FLAGS MATCHES "-march=")
+       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARM_GCC_ARCH_FLAG}" CACHE STRING "CXX Flags" FORCE)
+    endif()
+     if(NOT CMAKE_C_FLAGS MATCHES "-march=")
+       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ARM_GCC_ARCH_FLAG}" CACHE STRING "C Flags" FORCE)
+    endif()
+
+    # 2. Force EVE to recognize NEON support by defining its internal macro
+    #    This should influence EVE's headers during its own configuration via FetchContent.
+    #    Using add_compile_definitions ensures it's passed via -D to the compiler.
+    add_compile_definitions(EVE_SUPPORTS_NEON)
+
 endif()
 
 project(svs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,15 @@ target_compile_options(
     "-DSVS_VERSION_PATCH=${SVS_VERSION_PATCH}"
 )
 
+# Explicitly define ARM NEON macros for GCC on AArch64
+# This helps EVE's internal detection mechanism which seems problematic with GCC.
+# We define __ARM_NEON (standard macro) and EVE_ARM_64 (EVE specific).
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
+   CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64" AND
+   (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
+    add_compile_definitions(__ARM_NEON EVE_ARM_64)
+endif()
+
 #####
 ##### Options and extra build steps
 #####

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
    CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64" AND
    (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
     add_compile_definitions(__ARM_NEON EVE_ARM_64)
+
+    if(NOT CMAKE_CXX_FLAGS MATCHES "-march=")
+       string(APPEND CMAKE_CXX_FLAGS_INIT " -march=armv8-a")
+       string(APPEND CMAKE_C_FLAGS_INIT " -march=armv8-a")
+    endif()
+
 endif()
 
 #####

--- a/cmake/eve.cmake
+++ b/cmake/eve.cmake
@@ -16,7 +16,7 @@ Include(FetchContent)
 FetchContent_Declare(
     eve
     GIT_REPOSITORY https://github.com/jfalcou/eve
-    GIT_TAG v2022.09.1
+    GIT_TAG v2023.02.15
 )
 
 set(EVE_BUILD_TEST OFF)

--- a/cmake/eve.cmake
+++ b/cmake/eve.cmake
@@ -16,7 +16,7 @@ Include(FetchContent)
 FetchContent_Declare(
     eve
     GIT_REPOSITORY https://github.com/jfalcou/eve
-    GIT_TAG v2023.02.15
+    GIT_TAG 1666dae546371ea11c84ffc197e98a372afaa988
 )
 
 # Set EVE-specific CMake options *before* FetchContent_MakeAvailable

--- a/cmake/eve.cmake
+++ b/cmake/eve.cmake
@@ -19,6 +19,30 @@ FetchContent_Declare(
     GIT_TAG v2023.02.15
 )
 
+# Set EVE-specific CMake options *before* FetchContent_MakeAvailable
+# Force the architecture detection for GCC on Linux ARM (AArch64)
+# This should bypass problematic internal detection.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
+   CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64" AND
+   (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR NOT CMAKE_CXX_COMPILER_ID) # Check early
+  )
+    message(STATUS "ARM Linux GCC detected: Forcing EVE architecture via EVE_TARGET_ARCH=arm_v8")
+    # Set the CMake variable EVE uses to identify the target architecture.
+    # 'arm_v8' typically implies NEON/ASIMD support within EVE's logic.
+    # Check EVE documentation/CMake files for the exact variable name if this doesn't work.
+    set(EVE_TARGET_ARCH "arm_v8" CACHE STRING "Force EVE target architecture" FORCE)
+
+    # Also ensure the compiler itself targets a compatible architecture
+    if(NOT CMAKE_CXX_FLAGS MATCHES "-march=")
+       string(APPEND CMAKE_CXX_FLAGS_INIT " -march=armv8-a")
+       string(APPEND CMAKE_C_FLAGS_INIT " -march=armv8-a")
+       # Update the cache variables as well, just in case
+       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv8-a" CACHE STRING "CXX Flags" FORCE)
+       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8-a" CACHE STRING "C Flags" FORCE)
+    endif()
+
+endif()
+
 set(EVE_BUILD_TEST OFF)
 FetchContent_MakeAvailable(eve)
 target_link_libraries(${SVS_LIB} INTERFACE eve::eve)

--- a/cmake/eve.cmake
+++ b/cmake/eve.cmake
@@ -19,30 +19,6 @@ FetchContent_Declare(
     GIT_TAG 1666dae546371ea11c84ffc197e98a372afaa988
 )
 
-# Set EVE-specific CMake options *before* FetchContent_MakeAvailable
-# Force the architecture detection for GCC on Linux ARM (AArch64)
-# This should bypass problematic internal detection.
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
-   CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64" AND
-   (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR NOT CMAKE_CXX_COMPILER_ID) # Check early
-  )
-    message(STATUS "ARM Linux GCC detected: Forcing EVE architecture via EVE_TARGET_ARCH=arm_v8")
-    # Set the CMake variable EVE uses to identify the target architecture.
-    # 'arm_v8' typically implies NEON/ASIMD support within EVE's logic.
-    # Check EVE documentation/CMake files for the exact variable name if this doesn't work.
-    set(EVE_TARGET_ARCH "arm_v8" CACHE STRING "Force EVE target architecture" FORCE)
-
-    # Also ensure the compiler itself targets a compatible architecture
-    if(NOT CMAKE_CXX_FLAGS MATCHES "-march=")
-       string(APPEND CMAKE_CXX_FLAGS_INIT " -march=armv8-a")
-       string(APPEND CMAKE_C_FLAGS_INIT " -march=armv8-a")
-       # Update the cache variables as well, just in case
-       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv8-a" CACHE STRING "CXX Flags" FORCE)
-       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8-a" CACHE STRING "C Flags" FORCE)
-    endif()
-
-endif()
-
 set(EVE_BUILD_TEST OFF)
 FetchContent_MakeAvailable(eve)
 target_link_libraries(${SVS_LIB} INTERFACE eve::eve)

--- a/include/svs/quantization/scalar/scalar.h
+++ b/include/svs/quantization/scalar/scalar.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "eve/algo.hpp"
+#include "eve/module/algo.hpp"
 
 // svs
 #include "svs/core/data/simple.h"


### PR DESCRIPTION
This PR updates eve to the last version.
Unfortunately the last stable release was long time ago, and the problem with GCC and ARM isn't solved in a stable release. So I updated eve to the last commit in the main branch. 