### PR TITLE
Add mutli-vector index and batch iterator support

### DIFF
--- a/include/svs/index/vamana/dynamic_index.h
+++ b/include/svs/index/vamana/dynamic_index.h
@@ -44,6 +44,8 @@
 
 namespace svs::index::vamana {
 
+template <typename Index, typename QueryType> class BatchIterator;
+
 /////
 ///// MutableVamanaIndex
 /////
@@ -1243,6 +1245,14 @@ class MutableVamanaIndex {
 
         // Call extension for distance computation
         return extensions::get_distance_ext(data_, distance_, internal_id, query);
+    }
+
+    template <typename QueryType>
+    auto make_batch_iterator(
+        std::span<const QueryType> query,
+        size_t extra_search_buffer_capacity = svs::UNSIGNED_INTEGER_PLACEHOLDER
+    ) const {
+        return BatchIterator(*this, query, extra_search_buffer_capacity);
     }
 };
 

--- a/include/svs/index/vamana/dynamic_index.h
+++ b/include/svs/index/vamana/dynamic_index.h
@@ -724,12 +724,13 @@ class MutableVamanaIndex {
     ///   Delete consolidation performs the actual removal of deleted entries from the
     ///   graph.
     ///
-    template <typename T> void delete_entries(const T& ids) {
+    template <typename T> size_t delete_entries(const T& ids) {
         translator_.check_external_exist(ids.begin(), ids.end());
         for (auto i : ids) {
             delete_entry(translator_.get_internal(i));
         }
         translator_.delete_external(ids);
+        return ids.size();
     }
 
     void delete_entry(size_t i) {

--- a/include/svs/index/vamana/index.h
+++ b/include/svs/index/vamana/index.h
@@ -48,6 +48,8 @@
 
 namespace svs::index::vamana {
 
+template <typename Index, typename QueryType> class BatchIterator;
+
 struct VamanaIndexParameters {
     // Members
   public:
@@ -882,6 +884,14 @@ class VamanaIndex {
 
         // Call extension for distance computation
         return extensions::get_distance_ext(data_, distance_, id, query);
+    }
+
+    template <typename QueryType>
+    auto make_batch_iterator(
+        std::span<const QueryType> query,
+        size_t extra_search_buffer_capacity = svs::UNSIGNED_INTEGER_PLACEHOLDER
+    ) const {
+        return BatchIterator(*this, query, extra_search_buffer_capacity);
     }
 };
 

--- a/include/svs/index/vamana/multi.h
+++ b/include/svs/index/vamana/multi.h
@@ -41,7 +41,7 @@ template <typename Index, typename QueryType> class MultiBatchIterator {
     using const_iterator = typename result_buffer_type::const_iterator;
 
     using ParentIndex = typename Index::ParentIndex;
-    using compare = Index::compare;
+    using compare = typename Index::compare;
 
   public:
     MultiBatchIterator(

--- a/include/svs/index/vamana/multi.h
+++ b/include/svs/index/vamana/multi.h
@@ -331,7 +331,8 @@ class MultiMutableVamanaIndex {
         return adds;
     }
 
-    template <typename T> void delete_entries(const T& labels) {
+    // Return the number of deleted vectors
+    template <typename T> size_t delete_entries(const T& labels) {
         std::vector<external_id_type> deletes;
 
         for (auto& label : labels) {
@@ -346,6 +347,7 @@ class MultiMutableVamanaIndex {
             }
         }
         index_->delete_entries(deletes);
+        return deletes.size();
     }
 
     template <typename Query>

--- a/include/svs/index/vamana/multi.h
+++ b/include/svs/index/vamana/multi.h
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2025 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "svs/index/vamana/dynamic_index.h"
+#include "svs/index/vamana/iterator.h"
+
+namespace svs::index::vamana {
+
+/// @brief A multi-vector batch iterator for retrieving neighbors with unique labels from
+/// the index in batches.
+///
+/// This iterator abstracts the process of retrieving neighbors in fixed-size batches
+/// while maintaining internal state for efficient graph traversal.
+/// In multi-vector scenario,
+/// each label can have multiple vectors.
+/// This iterator ensures that neighbors are retrieved with unique labels
+template <typename Index, typename QueryType> class MultiBatchIterator {
+    using label_type = size_t;
+    using external_id_type = size_t;
+    using value_type = Neighbor<label_type>;
+
+    // Private type aliases
+    using result_buffer_type = std::vector<value_type>;
+    /// Random-access iterator to `value_type` over the current batch of results.
+    using iterator = typename result_buffer_type::iterator;
+    /// Random-access iterator to `const value_type` over the current batch of results.
+    using const_iterator = typename result_buffer_type::const_iterator;
+
+    using ParentIndex = typename Index::ParentIndex;
+
+  public:
+    MultiBatchIterator(
+        Index& index,
+        std::span<const QueryType> query,
+        size_t extra_search_buffer_capacity = svs::UNSIGNED_INTEGER_PLACEHOLDER
+    )
+        : index_{index}
+        , batch_iterator_{index.get_parent_index(), query, extra_search_buffer_capacity} {}
+
+    void next(
+        size_t batch_size,
+        const lib::DefaultPredicate& cancel = lib::Returns(lib::Const<false>())
+    ) {
+        const auto& external_to_label = index_.get_external_to_label_lookup();
+        results_.clear();
+        get_results_from_extra(batch_size);
+
+        while (results_.size() < batch_size && !batch_iterator_.done()) {
+            batch_iterator_.next(batch_size, cancel);
+            for (auto& result : batch_iterator_) {
+                auto label = external_to_label.at(result.id());
+
+                if (returned_.find(label) == returned_.end()) {
+                    returned_.insert(label);
+                    if (results_.size() < batch_size) {
+                        results_.push_back(Neighbor<label_type>{label, result.distance()});
+                    } else {
+                        extra_results_.push_back(Neighbor<label_type>{
+                            label, result.distance()});
+                    }
+                }
+            }
+        }
+        return;
+    }
+
+    void update(std::span<const QueryType> newquery) {
+        returned_.clear();
+        results_.clear();
+        extra_results_.clear();
+        batch_iterator_.update(newquery);
+    }
+
+    /// @brief Returns an iterator to the beginning of the results.
+    iterator begin() { return results_.begin(); }
+    /// @brief Returns an iterator to the end of the results.
+    iterator end() { return results_.end(); }
+    /// @copydoc begin()
+    const_iterator begin() const { return results_.begin(); }
+    /// @copydoc end()
+    const_iterator end() const { return results_.end(); }
+    /// @copydoc begin()
+    const_iterator cbegin() const { return results_.cbegin(); }
+    /// @copydoc begin()
+    const_iterator cend() const { return results_.cend(); }
+
+    bool done() const { return batch_iterator_.done() && extra_results_.empty(); }
+
+    std::span<const value_type> contents() const { return lib::as_const_span(results_); }
+
+  private:
+    void get_results_from_extra(size_t batch_size) {
+        std::sort(
+            extra_results_.begin(),
+            extra_results_.end(),
+            std::greater<Neighbor<label_type>>{}
+        );
+
+        while (results_.size() < batch_size && !extra_results_.empty()) {
+            auto top = extra_results_.front();
+            extra_results_.pop_back();
+
+            if (returned_.find(top.id()) == returned_.end()) {
+                returned_.insert(top.id());
+                results_.push_back(std::move(top));
+            }
+        }
+
+        return;
+    }
+
+    Index& index_;
+    std::unordered_set<label_type> returned_;
+    std::vector<Neighbor<label_type>> results_;
+    std::vector<Neighbor<label_type>> extra_results_;
+    BatchIterator<ParentIndex, QueryType> batch_iterator_;
+};
+
+template <typename Data, typename Dist> class MultiMutableVamanaIndex {
+  public:
+    using Graph = graphs::SimpleBlockedGraph<uint32_t>;
+    using ParentIndex = MutableVamanaIndex<Graph, Data, Dist>;
+    using Idx = typename ParentIndex::Idx;
+    using search_parameters_type = typename ParentIndex::search_parameters_type;
+    using external_id_type = typename ParentIndex::external_id_type;
+    using distance_type = Dist;
+    using label_type = size_t;
+
+  private:
+    distance_type distance_;
+    external_id_type counter_{0};
+    std::unique_ptr<ParentIndex> index_{nullptr};
+    std::unordered_map<label_type, std::vector<external_id_type>> label_to_external_;
+    std::unordered_map<external_id_type, label_type> external_to_label_;
+
+    template <class Labels>
+    void
+    prepare_added_id_by_label(const Labels& labels, std::vector<external_id_type>& adds) {
+        for (const auto l : labels) {
+            if (label_to_external_.find(l) == label_to_external_.end()) {
+                label_to_external_.insert({l, std::vector<external_id_type>{}});
+            }
+
+            size_t new_external_id = counter_++;
+            label_to_external_[l].push_back(new_external_id);
+            external_to_label_.insert({new_external_id, l});
+            adds.push_back(new_external_id);
+        }
+    }
+
+  public:
+    template <typename ThreadPoolProto, typename Labels>
+    MultiMutableVamanaIndex(
+        const VamanaBuildParameters& parameters,
+        Data data,
+        const Labels& labels,
+        Dist distance_function,
+        ThreadPoolProto threadpool_proto,
+        svs::logging::logger_ptr logger = svs::logging::get()
+    )
+        : distance_(std::move(distance_function)) {
+        std::vector<external_id_type> adds;
+        adds.reserve(labels.size());
+        prepare_added_id_by_label(labels, adds);
+        index_ = std::make_unique<ParentIndex>(
+            parameters,
+            std::move(data),
+            std::move(adds),
+            distance_,
+            std::move(threadpool_proto),
+            logger
+        );
+    }
+
+    const auto& get_label_to_external_lookup() const { return label_to_external_; }
+    const auto& get_external_to_label_lookup() const { return external_to_label_; }
+    const ParentIndex& get_parent_index() const { return *index_; }
+
+    template <typename Query>
+    double get_distance(label_type label, const Query& query) const {
+        double min = std::numeric_limits<double>::max();
+        auto it = label_to_external_.find(label);
+        if (it != label_to_external_.end()) {
+            auto& vectors = (*it).second;
+            for (auto each : vectors) {
+                min = std::min(min, index_->get_distance(each, query));
+            }
+        }
+
+        return min;
+    }
+
+    template <data::ImmutableMemoryDataset Points, typename Labels>
+    std::vector<label_type>
+    add_points(const Points& points, const Labels& labels, bool reuse_empty = false) {
+        const size_t num_points = points.size();
+        const size_t num_labels = labels.size();
+        if (num_points != num_labels) {
+            throw ANNEXCEPTION(
+                "Number of points ({}) not equal to the number of external ids ({})!",
+                num_points,
+                num_labels
+            );
+        }
+
+        std::vector<external_id_type> adds;
+        adds.reserve(num_labels);
+        prepare_added_id_by_label(labels, adds);
+        index_->add_points(points, adds, reuse_empty);
+
+        return adds;
+    }
+
+    template <typename T> void delete_entries(const T& labels) {
+        std::vector<external_id_type> deletes;
+
+        for (auto& label : labels) {
+            auto it = label_to_external_.find(label);
+            if (it != label_to_external_.end()) {
+                auto& externals = (*it).second;
+                deletes.insert(deletes.end(), externals.begin(), externals.end());
+                for (auto& ext : externals) {
+                    external_to_label_.erase(ext);
+                }
+                label_to_external_.erase(it);
+            }
+        }
+        index_->delete_entries(deletes);
+    }
+
+    template <typename I, data::ImmutableMemoryDataset Queries>
+    void search(
+        QueryResultView<I> results,
+        const Queries& queries,
+        const search_parameters_type& SVS_UNUSED(sp
+        ), // In this version, we assume search parameters are the same as index
+        const lib::DefaultPredicate& cancel = lib::Returns(lib::Const<false>())
+    ) {
+        auto& borrow_threadpool = index_->get_threadpool_handle();
+
+        threads::parallel_for(
+            borrow_threadpool,
+            threads::StaticPartition{queries.size()},
+            [&](const auto is, uint64_t SVS_UNUSED(tid)) {
+                size_t num_neighbors = results.n_neighbors();
+
+                // use batch iterator to search
+                for (auto i : is) {
+                    auto batch_iterator = generate_batch_iterator(queries.get_datum(i));
+                    batch_iterator.next(num_neighbors, cancel);
+                    size_t j{0};
+                    for (auto& res : batch_iterator) {
+                        results.set(res, i, j++);
+                    }
+
+                    for (; j < num_neighbors; ++j) {
+                        // insert default neighbor if not enough
+                        results.set(Neighbor<label_type>{}, i, j);
+                    }
+                }
+            }
+        );
+
+        return;
+    }
+
+    void compact(Idx batch_size = 1'000) { index_->compact(batch_size); }
+
+    void consolidate() { index_->consolidate(); }
+
+    template <typename QueryType>
+    auto generate_batch_iterator(std::span<const QueryType> query) const {
+        return MultiBatchIterator(*this, query, 1);
+    }
+
+    void set_threadpool(threads::ThreadPoolHandle threadpool) {
+        index_->set_threadpool(std::move(threadpool));
+    }
+
+    ///
+    /// @brief Destroy the original thread pool and set to the provided one.
+    ///
+    /// @param threadpool An acceptable thread pool.
+    ///
+    /// @copydoc threadpool_requirements
+    ///
+    template <threads::ThreadPool Pool>
+    void set_threadpool(Pool threadpool)
+        requires(!std::is_same_v<Pool, threads::ThreadPoolHandle>)
+    {
+        set_threadpool(threads::ThreadPoolHandle(std::move(threadpool)));
+    }
+
+    ///
+    /// @brief Return the current thread pool handle.
+    ///
+    threads::ThreadPoolHandle& get_threadpool_handle() {
+        return index_->get_threadpool_handle();
+    }
+
+    size_t size() const { return label_to_external_.size(); }
+};
+
+} // namespace svs::index::vamana

--- a/include/svs/index/vamana/multi.h
+++ b/include/svs/index/vamana/multi.h
@@ -166,13 +166,16 @@ class MultiMutableVamanaIndex {
     using label_type = size_t;
     using graph_type = Graph;
     using data_type = Data;
+    using label_to_external_type =
+        std::unordered_map<label_type, std::vector<external_id_type>>;
+    using external_to_label_type = std::unordered_map<external_id_type, label_type>;
 
   private:
     distance_type distance_;
     external_id_type counter_{0};
     std::unique_ptr<ParentIndex> index_{nullptr};
-    std::unordered_map<label_type, std::vector<external_id_type>> label_to_external_;
-    std::unordered_map<external_id_type, label_type> external_to_label_;
+    label_to_external_type label_to_external_;
+    external_to_label_type external_to_label_;
 
     template <class Labels>
     void
@@ -281,8 +284,12 @@ class MultiMutableVamanaIndex {
         );
     }
 
-    const auto& get_label_to_external_lookup() const { return label_to_external_; }
-    const auto& get_external_to_label_lookup() const { return external_to_label_; }
+    const label_to_external_type& get_label_to_external_lookup() const {
+        return label_to_external_;
+    }
+    const external_to_label_type& get_external_to_label_lookup() const {
+        return external_to_label_;
+    }
     const ParentIndex& get_parent_index() const { return *index_; }
 
     template <typename Query>

--- a/include/svs/index/vamana/multi.h
+++ b/include/svs/index/vamana/multi.h
@@ -40,7 +40,6 @@ template <typename Index, typename QueryType> class MultiBatchIterator {
     using compare = typename Index::compare;
 
   public:
-
     /// Random-access iterator to `value_type` over the current batch of results.
     using iterator = typename result_buffer_type::iterator;
     /// Random-access iterator to `const value_type` over the current batch of results.
@@ -420,7 +419,9 @@ class MultiMutableVamanaIndex {
         return index_->get_threadpool_handle();
     }
 
-    bool has_id(size_t e) const { return label_to_external_.find(e) != label_to_external_.end(); }
+    bool has_id(size_t e) const {
+        return label_to_external_.find(e) != label_to_external_.end();
+    }
 
     size_t size() const { return label_to_external_.size(); }
 
@@ -444,13 +445,23 @@ class MultiMutableVamanaIndex {
 
     size_t dimensions() const { return index_->dimensions(); }
 
-    void set_search_parameters(const VamanaSearchParameters& parameters) { index_->set_search_parameters(parameters); }
-    VamanaSearchParameters get_search_parameters() const { return index_->get_search_parameters(); }
+    void set_search_parameters(const VamanaSearchParameters& parameters) {
+        index_->set_search_parameters(parameters);
+    }
+    VamanaSearchParameters get_search_parameters() const {
+        return index_->get_search_parameters();
+    }
 
-    void set_construction_window_size(size_t window_size) { index_->set_construction_window_size(window_size); }
-    size_t get_construction_window_size() const { return index_->get_construction_window_size(); }
+    void set_construction_window_size(size_t window_size) {
+        index_->set_construction_window_size(window_size);
+    }
+    size_t get_construction_window_size() const {
+        return index_->get_construction_window_size();
+    }
 
-    void set_max_candidates(size_t max_candidate_pool_size) { index_->set_max_candidates(max_candidate_pool_size); }
+    void set_max_candidates(size_t max_candidate_pool_size) {
+        index_->set_max_candidates(max_candidate_pool_size);
+    }
     size_t get_max_candidates() const { return index_->get_max_candidates(); }
 
     void set_prune_to(size_t prune_to) { index_->set_prune_to(prune_to); }
@@ -459,10 +470,10 @@ class MultiMutableVamanaIndex {
     void set_alpha(float alpha) { index_->set_alpha(alpha); }
     float get_alpha() const { return index_->get_alpha(); }
 
-    void set_full_search_history(bool use_full_search_history) { index_->set_full_search_history(use_full_search_history); }
+    void set_full_search_history(bool use_full_search_history) {
+        index_->set_full_search_history(use_full_search_history);
+    }
     bool get_full_search_history() const { return index_->get_full_search_history(); }
-
-
 };
 
 ///// Deduction Guides.

--- a/include/svs/lib/preprocessor.h
+++ b/include/svs/lib/preprocessor.h
@@ -172,6 +172,7 @@ inline constexpr float VAMANA_WINDOW_SIZE_DEFAULT = 64;
 inline constexpr bool VAMANA_USE_FULL_SEARCH_HISTORY_DEFAULT = true;
 inline constexpr float VAMANA_ALPHA_MINIMIZE_DEFAULT = 1.2;
 inline constexpr float VAMANA_ALPHA_MAXIMIZE_DEFAULT = 0.95;
+inline constexpr double INVALID_DISTANCE = std::numeric_limits<double>::quiet_NaN();
 
 // Default value used for extra search buffer capacity in the batch iterator.
 inline constexpr size_t ITERATOR_EXTRA_BUFFER_CAPACITY_DEFAULT = 100;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -137,6 +137,7 @@ set(TEST_SOURCES
     #${TEST_DIR}/svs/index/vamana/iterator_schedule.cpp
     ${TEST_DIR}/svs/index/vamana/iterator_example.cpp
     ${TEST_DIR}/svs/index/vamana/iterator.cpp
+    ${TEST_DIR}/svs/index/vamana/multi.cpp
     # Inverted
     ${TEST_DIR}/svs/index/inverted/clustering.cpp
     ${TEST_DIR}/svs/index/inverted/memory_based.cpp

--- a/tests/svs/index/vamana/multi.cpp
+++ b/tests/svs/index/vamana/multi.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// header under test
+#include "svs/index/vamana/multi.h"
+
+// svstest
+#include "tests/utils/test_dataset.h"
+#include "tests/utils/vamana_reference.h"
+
+// catch2
+#include "catch2/catch_test_macros.hpp"
+
+// stl
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+using Eltype = float;
+using QueryEltype = float;
+using Distance = svs::distance::DistanceL2;
+
+CATCH_TEST_CASE("Vamana Multi", "[index][vamana][multi]") {
+    const size_t N = 128;
+    const size_t max_degree = 64;
+    const float alpha = 1.2;
+    const size_t num_threads = 4;
+    const size_t num_neighbors = 10;
+
+    const auto data = svs::data::SimpleData<Eltype, N>::load(test_dataset::data_svs_file());
+    const auto num_points = data.size();
+    const auto queries = test_dataset::queries();
+    const auto groundtruth = test_dataset::load_groundtruth(svs::distance_type_v<Distance>);
+
+    const svs::index::vamana::VamanaBuildParameters build_parameters{
+        alpha, max_degree, 2 * max_degree, 1000, max_degree - 4, true};
+
+    const auto search_parameters = svs::index::vamana::VamanaSearchParameters();
+    const size_t num_duplicated = 3;
+
+    float epsilon = 0.005f;
+
+    CATCH_SECTION("Insertion/Deletion in duplicated test datasets") {
+        std::vector<size_t> indices(num_points);
+        std::iota(indices.begin(), indices.end(), 0);
+
+        auto index = svs::index::vamana::MultiMutableVamanaIndex(
+            build_parameters, data, indices, Distance(), num_threads
+        );
+
+        for (size_t i = 0; i < num_duplicated; ++i) {
+            std::iota(indices.begin(), indices.end(), i + 1);
+            index.add_points(data, indices);
+        }
+        CATCH_REQUIRE(index.size() == indices.size() + num_duplicated);
+        CATCH_REQUIRE(
+            index.get_parent_index().size() == indices.size() * (num_duplicated + 1)
+        );
+
+        std::iota(indices.begin(), indices.end(), 0);
+        index.delete_entries(indices);
+        CATCH_REQUIRE(index.size() == num_duplicated);
+        CATCH_REQUIRE(
+            index.get_parent_index().size() == (num_duplicated * (num_duplicated + 1)) / 2
+        );
+    }
+    CATCH_SECTION("Same vector with same labels") {
+        std::vector<size_t> indices(num_points);
+        std::iota(indices.begin(), indices.end(), 0);
+
+        auto index = svs::index::vamana::MultiMutableVamanaIndex(
+            build_parameters, data, indices, Distance(), num_threads
+        );
+        auto ref_results = svs::QueryResult<size_t>(queries.size(), num_neighbors);
+        index.search(ref_results.view(), queries.view(), search_parameters);
+        auto ref_recall = svs::k_recall_at_n(groundtruth, ref_results);
+
+        for (size_t i = 0; i < num_duplicated; ++i) {
+            index.add_points(data, indices);
+        }
+        CATCH_REQUIRE(index.size() == indices.size());
+        CATCH_REQUIRE(
+            index.get_parent_index().size() == indices.size() * (num_duplicated + 1)
+        );
+
+        auto test_results = svs::QueryResult<size_t>(queries.size(), num_neighbors);
+        index.search(test_results.view(), queries.view(), search_parameters);
+        auto test_recall = svs::k_recall_at_n(groundtruth, test_results);
+
+        CATCH_REQUIRE(test_recall > ref_recall - epsilon);
+
+        index.delete_entries(indices);
+        CATCH_REQUIRE(index.size() == 0);
+        CATCH_REQUIRE(index.get_parent_index().size() == 0);
+    }
+
+    CATCH_SECTION("Get distance") {}
+}

--- a/tests/svs/index/vamana/multi.cpp
+++ b/tests/svs/index/vamana/multi.cpp
@@ -22,6 +22,7 @@
 #include "tests/utils/vamana_reference.h"
 
 // catch2
+#include "catch2/catch_template_test_macros.hpp"
 #include "catch2/catch_test_macros.hpp"
 
 // stl
@@ -30,14 +31,33 @@
 #include <vector>
 
 namespace {
-using Eltype = float;
-using Distance = svs::distance::DistanceL2;
+
+template <typename Distance> float pick_alpha(Distance SVS_UNUSED(dist)) {
+    if constexpr (std::is_same_v<Distance, svs::DistanceL2>) {
+        return 1.2;
+    } else if constexpr (std::is_same_v<Distance, svs::DistanceIP>) {
+        return 0.95;
+    } else if constexpr (std::is_same_v<Distance, svs::DistanceCosineSimilarity>) {
+        return 0.95;
+    } else {
+        throw ANNEXCEPTION("Unsupported distance type!");
+    }
+}
+
 } // namespace
 
-CATCH_TEST_CASE("Multi-vector dynamic vamana index", "[index][vamana][multi]") {
+CATCH_TEMPLATE_TEST_CASE(
+    "Multi-vector dynamic vamana index",
+    "[index][vamana][multi]",
+    svs::DistanceL2,
+    svs::DistanceIP,
+    svs::DistanceCosineSimilarity
+) {
+    using Eltype = float;
+    using Distance = TestType;
     const size_t N = 128;
     const size_t max_degree = 64;
-    const float alpha = 1.2;
+    const float alpha = pick_alpha(Distance());
     const size_t num_threads = 4;
     const size_t num_neighbors = 10;
 


### PR DESCRIPTION
This PR introduces multi-vector indexing and batch iterator functionality. With this PR, each label can be associated with multiple vectors, while ensuring that neighbors are retrieved with unique labels during search.

- Key APIs for `MultiBatchIterator`:
`next`: Retrieve a batch of neighbors, ensuring each neighbor has a unique label.

- Key APIs for `MultiMutableVamanaIndex`:
`search`: Utilize `MultiBatchIterator` to perform searches.
`add_points`: Allow the addition of points to the index, associating each with a corresponding label. Points with the same label can be added without issue.
`delete_entries`: Remove all vectors associated with a specific label from the index.
`get_distance`: Return the shortest distance among vectors with the given label and query.
`make_batch_iterator`: Return a `MultiBatchIterator` associated with the current index.

- Add `make_batch_iterator` to `MutableVamanaIndex` and `VamanaIndex` as well to enhance functionality.


#TODOs:

- [x] Add more unittests
- [x] Add different types of distance into unittests
- [ ] Documentation
- [ ] (TBD) Disable translator in `MutableVamana` for `MultiMutableVamanaIndex`
- [ ]  Elevate `MultiMutableVamana` at orchestrator/type-ersure level and eventually to python bindings



