### PR TITLE
Mark iterator done when no more new neighbors can be retreived,

### DIFF
--- a/include/svs/index/vamana/iterator.h
+++ b/include/svs/index/vamana/iterator.h
@@ -182,6 +182,7 @@ template <typename Index, typename QueryType> class BatchIterator {
         iteration_ = 0;
         yielded_.clear();
         results_.clear();
+        is_exhausted_ = false;
     }
 
     /// @brief Adapts an internal neighbor to an external neighbor.
@@ -217,12 +218,14 @@ template <typename Index, typename QueryType> class BatchIterator {
     /// @brief Return the batch number corresponding to the current buffer.
     size_t batch_number() const { return iteration_; }
 
-    /// @brief Return whether the entire entries in the index have been yielded.
+    /// @brief Returns whether iterator can find more neighbors or not for the given query.
     ///
-    /// The transition from not done to done will be triggered by a call to ``next()``.
-    /// The contents of ``batch_number()`` and ``parameters_for_current_iteration()`` will
-    /// then remain unchanged by subsequent invocations of ``next()``.
-    bool done() const { return yielded_.size() == parent_->size(); }
+    /// The iterator is considered done when all the available nodes have been yielded or
+    /// when the search can not find any more neighbors. The transition from not done to
+    /// done will be triggered by a call to ``next()``. The contents of ``batch_number()``
+    /// and ``parameters_for_current_iteration()`` will then remain unchanged by subsequent
+    /// invocations of ``next()``.
+    bool done() const { return (yielded_.size() == parent_->size() || is_exhausted_); }
 
     /// @brief Forces the next iteration to restart the search from scratch.
     void restart_next_search() { restart_search_ = true; }
@@ -306,6 +309,11 @@ template <typename Index, typename QueryType> class BatchIterator {
         ++iteration_;
         restart_search_ = false;
         copy_from_scratch(batch_size);
+        // If result is empty after calling next(), mark the iterator as exhausted.
+        // The iterator will not be able to find any more neighbors.
+        if (results_.size() == 0 && batch_size > 0) {
+            is_exhausted_ = true;
+        }
     }
 
   private:
@@ -318,6 +326,7 @@ template <typename Index, typename QueryType> class BatchIterator {
     bool restart_search_ = true; // Whether the next search should restart from scratch.
     size_t extra_search_buffer_capacity_ =
         svs::UNSIGNED_INTEGER_PLACEHOLDER; // Extra buffer capacity for the next search.
+    bool is_exhausted_ = false; // Whether the iterator is exhausted.
 };
 
 // Deduction Guides

--- a/include/svs/orchestrators/vamana_iterator.h
+++ b/include/svs/orchestrators/vamana_iterator.h
@@ -160,12 +160,13 @@ class VamanaIterator {
     /// This can be helpful for measuring performance and verifying recall values.
     void restart_next_search() const { impl_->restart_next_search(); }
 
-    /// @brief Return whether or not all entries in the index have been yielded.
+    /// @brief Returns whether iterator can find more neighbors or not for the given query.
     ///
-    /// This transition is triggered by an invocation of ``next()``.
-    /// After ``done() == true``, future calls to ``next()`` will yield an empty set of
-    /// candidates and will not change the results of ``batch_number()`` or
-    /// ``parameters_for_current_iteration()``.
+    /// The iterator is considered done when all the available nodes have been yielded or
+    /// when the search can not find any more neighbors. The transition from not done to
+    /// done will be triggered by a call to ``next()``. The contents of ``batch_number()``
+    /// and ``parameters_for_current_iteration()`` will then remain unchanged by subsequent
+    /// invocations of ``next()``.
     bool done() const { return impl_->done(); }
 
     /// @brief Update the iterator with a new query.


### PR DESCRIPTION
Mark the iterator done when no more new neighbors can be retrieved, even though there may be more nodes available in the index.