### PR TITLE
Fix multi-vector batch iterator done() issue

### DIFF
--- a/include/svs/index/vamana/multi.h
+++ b/include/svs/index/vamana/multi.h
@@ -118,7 +118,10 @@ template <typename Index, typename QueryType> class MultiBatchIterator {
     const_iterator cend() const { return results_.cend(); }
     size_t size() const { return results_.size(); }
 
-    bool done() const { return batch_iterator_.done() && extra_results_.empty(); }
+    bool done() const {
+        return (batch_iterator_.done() && extra_results_.empty()) ||
+               (returned_.size() == index_.labelcount());
+    }
 
     std::span<const value_type> contents() const { return lib::as_const_span(results_); }
 


### PR DESCRIPTION
With this PR, we can immediately detect if all labels are found without exhaustively checking all vectors.