### PR TITLE
Add get_logger in multi index and enable clang format

### DIFF
--- a/examples/cpp/shared/shared.cpp
+++ b/examples/cpp/shared/shared.cpp
@@ -69,12 +69,12 @@ auto create_lvq_data() {
 template <typename Data, typename Distance>
 void vamana_build(Data& data, Distance distance) {
     auto parameters = svs::index::vamana::VamanaBuildParameters{
-        1.2,                 // alpha
-        64,                  // graph max degree
-        128,                 // search window size
-        750,                 // max candidate pool size
-        60,                  // prune to degree
-        true,                // full search history
+        1.2,  // alpha
+        64,   // graph max degree
+        128,  // search window size
+        750,  // max candidate pool size
+        60,   // prune to degree
+        true, // full search history
     };
 
     auto tic = svs::lib::now();

--- a/include/svs/index/vamana/iterator.h
+++ b/include/svs/index/vamana/iterator.h
@@ -326,7 +326,7 @@ template <typename Index, typename QueryType> class BatchIterator {
     bool restart_search_ = true; // Whether the next search should restart from scratch.
     size_t extra_search_buffer_capacity_ =
         svs::UNSIGNED_INTEGER_PLACEHOLDER; // Extra buffer capacity for the next search.
-    bool is_exhausted_ = false; // Whether the iterator is exhausted.
+    bool is_exhausted_ = false;            // Whether the iterator is exhausted.
 };
 
 // Deduction Guides

--- a/include/svs/index/vamana/multi.h
+++ b/include/svs/index/vamana/multi.h
@@ -295,6 +295,8 @@ class MultiMutableVamanaIndex {
     }
     const ParentIndex& get_parent_index() const { return *index_; }
 
+    svs::logging::logger_ptr get_logger() const { return index_->get_logger(); }
+
     template <typename Query>
     double get_distance(label_type label, const Query& query) const {
         double best = INVALID_DISTANCE;

--- a/tests/svs/index/vamana/multi.cpp
+++ b/tests/svs/index/vamana/multi.cpp
@@ -229,4 +229,15 @@ CATCH_TEMPLATE_TEST_CASE(
             CATCH_REQUIRE(test_distance == ref_distance);
         }
     }
+
+    CATCH_SECTION("Logging") {
+        std::vector<size_t> test_indices(num_points);
+        std::iota(test_indices.begin(), test_indices.end(), 0);
+
+        auto test_index = svs::index::vamana::MultiMutableVamanaIndex(
+            build_parameters, data, test_indices, Distance(), num_threads
+        );
+
+        CATCH_REQUIRE(ref_index.get_logger() == test_index.get_logger());
+    }
 }


### PR DESCRIPTION
This PR adds the `get_logger` utility in multi-vector index as well as applies clang format to files that were previously unformatted.
