### PR TITLE
Enable AVX512 if VNNI is supported and remove fpic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,14 +68,6 @@ target_compile_options(
 #####
 
 include("cmake/options.cmake")
-
-add_library(svs_x86_options_base INTERFACE)
-add_library(svs::x86_options_base ALIAS svs_x86_options_base)
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
-    target_compile_options(svs_x86_options_base INTERFACE -march=nehalem -mtune=nehalem)
-    include("cmake/multi-arch.cmake")
-endif()
-
 include("cmake/clang-tidy.cmake")
 include("cmake/eve.cmake")
 include("cmake/pthread.cmake")
@@ -84,6 +76,13 @@ include("cmake/robin-map.cmake")
 include("cmake/fmt.cmake")
 include("cmake/spdlog.cmake")
 include("cmake/toml.cmake")
+
+add_library(svs_x86_options_base INTERFACE)
+add_library(svs::x86_options_base ALIAS svs_x86_options_base)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
+    target_compile_options(svs_x86_options_base INTERFACE -march=nehalem -mtune=nehalem)
+    include("cmake/multi-arch.cmake")
+endif()
 
 #####
 ##### Build Objects

--- a/cmake/multi-arch.cmake
+++ b/cmake/multi-arch.cmake
@@ -31,7 +31,6 @@ foreach(x86_info IN LISTS SVS_X86)
 
     add_library(${obj_name} OBJECT ${src})
     target_link_libraries(${obj_name} PRIVATE ${SVS_LIB} svs::compile_options fmt::fmt ${lib_name})
-    set_target_properties(${obj_name} PROPERTIES POSITION_INDEPENDENT_CODE ON)
     list(APPEND SVS_X86_OBJECT_FILES $<TARGET_OBJECTS:${obj_name}>)
 endforeach()
 

--- a/include/svs/core/distance/cosine.h
+++ b/include/svs/core/distance/cosine.h
@@ -286,7 +286,9 @@ struct CosineSimilarityImpl<N, int8_t, int8_t, AVX_AVAILABILITY::AVX512> {
             return lib::narrow_cast<float>(_mm512_reduce_add_epi32(sum)) /
                    (a_norm * b_norm);
         }
-        return CosineSimilarityImpl<N, int8_t, int8_t, AVX_AVAILABILITY::AVX2>::compute(a, b, a_norm, length);
+        // Fallback to AVX512
+        auto [sum, norm] = simd::generic_simd_op(CosineFloatOp<16>(), a, b, length);
+        return sum / (std::sqrt(norm) * a_norm);
     }
 };
 
@@ -317,7 +319,9 @@ struct CosineSimilarityImpl<N, uint8_t, uint8_t, AVX_AVAILABILITY::AVX512> {
             return lib::narrow_cast<float>(_mm512_reduce_add_epi32(sum)) /
                    (a_norm * b_norm);
         }
-        return CosineSimilarityImpl<N, uint8_t, uint8_t, AVX_AVAILABILITY::AVX2>::compute(a, b, a_norm, length);
+        // Fallback to AVX512
+        auto [sum, norm] = simd::generic_simd_op(CosineFloatOp<16>(), a, b, length);
+        return sum / (std::sqrt(norm) * a_norm);
     }
 };
 

--- a/include/svs/core/distance/euclidean.h
+++ b/include/svs/core/distance/euclidean.h
@@ -296,8 +296,8 @@ template <size_t N> struct L2Impl<N, int8_t, int8_t, AVX_AVAILABILITY::AVX512> {
         if (__builtin_expect(svs::detail::avx_runtime_flags.is_avx512vnni_supported(), 1)) {
             return simd::generic_simd_op(L2VNNIOp<int16_t, 32>(), a, b, length);
         }
-        // fallback to AVX2
-        return L2Impl<N, int8_t, int8_t, AVX_AVAILABILITY::AVX2>::compute(a, b, length);
+        // fallback to AVX512
+        return simd::generic_simd_op(L2FloatOp<16>{}, a, b, length);
     }
 };
 
@@ -307,8 +307,8 @@ template <size_t N> struct L2Impl<N, uint8_t, uint8_t, AVX_AVAILABILITY::AVX512>
         if (__builtin_expect(svs::detail::avx_runtime_flags.is_avx512vnni_supported(), 1)) {
             return simd::generic_simd_op(L2VNNIOp<int16_t, 32>(), a, b, length);
         }
-        // fallback to AVX2
-        return L2Impl<N, uint8_t, uint8_t, AVX_AVAILABILITY::AVX2>::compute(a, b, length);
+        // fallback to AVX512
+        return simd::generic_simd_op(L2FloatOp<16>{}, a, b, length);
     }
 };
 

--- a/include/svs/core/distance/inner_product.h
+++ b/include/svs/core/distance/inner_product.h
@@ -250,8 +250,8 @@ template <size_t N> struct IPImpl<N, int8_t, int8_t, AVX_AVAILABILITY::AVX512> {
         if (__builtin_expect(svs::detail::avx_runtime_flags.is_avx512vnni_supported(), 1)) {
             return simd::generic_simd_op(IPVNNIOp<int16_t, 32>(), a, b, length);
         }
-        // fallback to AVX2
-        return IPImpl<N, int8_t, int8_t, AVX_AVAILABILITY::AVX2>::compute(a, b, length);
+        // fallback to AVX512
+        return svs::simd::generic_simd_op(IPFloatOp<16>{}, a, b, length);
     }
 };
 
@@ -261,8 +261,8 @@ template <size_t N> struct IPImpl<N, uint8_t, uint8_t, AVX_AVAILABILITY::AVX512>
         if (__builtin_expect(svs::detail::avx_runtime_flags.is_avx512vnni_supported(), 1)) {
             return simd::generic_simd_op(IPVNNIOp<int16_t, 32>(), a, b, length);
         }
-        // fallback to AVX2
-        return IPImpl<N, uint8_t, uint8_t, AVX_AVAILABILITY::AVX2>::compute(a, b, length);
+        // fallback to AVX512
+        return svs::simd::generic_simd_op(IPFloatOp<16>{}, a, b, length);
     }
 };
 


### PR DESCRIPTION
This PR enables AVX512 when VNNI is not supported. Additionally, it eliminates the requirement to use -fpic in CMake files, which can degrade performance.