### PR TITLE
ISA dispatcher update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ include("cmake/toml.cmake")
 add_library(svs_x86_options_base INTERFACE)
 add_library(svs::x86_options_base ALIAS svs_x86_options_base)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
-    target_compile_options(svs_x86_options_base INTERFACE -march=ivybridge -mtune=ivybridge)
+    target_compile_options(svs_x86_options_base INTERFACE -march=x86-64 -mtune=generic)
     include("cmake/multi-arch.cmake")
 endif()
 

--- a/include/svs/third-party/eve.h
+++ b/include/svs/third-party/eve.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "eve/detection.hpp"
 #include "eve/module/core.hpp"
 #include "eve/wide.hpp"
 


### PR DESCRIPTION
Update the base arch to generic and remove the unused eve file that causes issues on non-AVX machine.