### PR TITLE
fix: add flag

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -162,6 +162,7 @@ target_compile_options(
         -Wpedantic
         -Wno-gnu-zero-variadic-macro-arguments
         -Wno-parentheses # GCC in CI has issues without it
+        -fsized-deallocation
 )
 
 


### PR DESCRIPTION
This PR targets to fix redis team's problem on operator delete mismatch errors with clang that required adding -fsized-deallocation to fix