### PR TITLE
Add svs::Dynamic in dimension support list

### DIFF
--- a/include/svs/core/distance/distance_core.h
+++ b/include/svs/core/distance/distance_core.h
@@ -28,7 +28,7 @@ namespace svs::distance {
 
 enum class AVX_AVAILABILITY { NONE, AVX2, AVX512 };
 
-constexpr std::array<size_t, 8> supported_dim_list{64, 96, 100, 128, 160, 200, 512, 768};
+constexpr std::array<size_t, 8> supported_dim_list{64, 96, 100, 128, 160, 200, 512, 768, svs::Dynamic};
 
 template <size_t N> constexpr bool is_dim_supported() {
     for (auto i : supported_dim_list) {

--- a/include/svs/core/distance/distance_core.h
+++ b/include/svs/core/distance/distance_core.h
@@ -28,7 +28,7 @@ namespace svs::distance {
 
 enum class AVX_AVAILABILITY { NONE, AVX2, AVX512 };
 
-constexpr std::array<size_t, 8> supported_dim_list{64, 96, 100, 128, 160, 200, 512, 768, svs::Dynamic};
+constexpr std::array<size_t, 9> supported_dim_list{64, 96, 100, 128, 160, 200, 512, 768, svs::Dynamic};
 
 template <size_t N> constexpr bool is_dim_supported() {
     for (auto i : supported_dim_list) {


### PR DESCRIPTION
In this PR, add `svs::Dynamic` in dimension support list to avoid unwanted ISA switching overhead.