### PR TITLE
Fix graph building with SQdata

### DIFF
--- a/include/svs/core/distance/distance_core.h
+++ b/include/svs/core/distance/distance_core.h
@@ -28,7 +28,8 @@ namespace svs::distance {
 
 enum class AVX_AVAILABILITY { NONE, AVX2, AVX512 };
 
-constexpr std::array<size_t, 9> supported_dim_list{64, 96, 100, 128, 160, 200, 512, 768, svs::Dynamic};
+constexpr std::array<size_t, 9> supported_dim_list{
+    64, 96, 100, 128, 160, 200, 512, 768, svs::Dynamic};
 
 template <size_t N> constexpr bool is_dim_supported() {
     for (auto i : supported_dim_list) {

--- a/include/svs/extensions/flat/scalar.h
+++ b/include/svs/extensions/flat/scalar.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "svs/index/flat/flat.h"
+#include "svs/quantization/scalar/scalar.h"
+
+namespace svs::quantization::scalar {
+
+template <IsSQData Data, typename Distance>
+auto svs_invoke(
+    svs::tag_t<svs::index::flat::extensions::distance>,
+    const Data& data,
+    const Distance& SVS_UNUSED(distance)
+) {
+    return compressed_distance_t<Distance, typename Data::element_type>(
+        data.get_scale(), data.get_bias(), data.dimensions()
+    );
+}
+
+} // namespace svs::quantization::scalar

--- a/include/svs/extensions/vamana/scalar.h
+++ b/include/svs/extensions/vamana/scalar.h
@@ -69,7 +69,6 @@ template <IsSQData Data, typename Distance> struct VamanaBuildAdaptor {
     general_distance_type& general_distance() { return distance_; }
     data::GetDatumAccessor general_accessor() const { return data::GetDatumAccessor{}; }
 
-
     template <typename Query, NeighborLike N>
     SVS_FORCE_INLINE Neighbor<typename N::index_type> post_search_modify(
         const Data& SVS_UNUSED(data),

--- a/include/svs/index/vamana/dynamic_index.h
+++ b/include/svs/index/vamana/dynamic_index.h
@@ -304,8 +304,7 @@ class MutableVamanaIndex {
                 sp.search_buffer_visited_set_
             ),
             extensions::single_search_setup(data_, distance_),
-            {sp.prefetch_lookahead_, sp.prefetch_step_}
-        };
+            {sp.prefetch_lookahead_, sp.prefetch_step_}};
     }
 
     scratchspace_type scratchspace() const { return scratchspace(get_search_parameters()); }
@@ -512,8 +511,7 @@ class MutableVamanaIndex {
                     search_buffer_type{sp.buffer_config_, distance::comparator(distance_)};
 
                 auto prefetch_parameters = GreedySearchPrefetchParameters{
-                    sp.prefetch_lookahead_, sp.prefetch_step_
-                };
+                    sp.prefetch_lookahead_, sp.prefetch_step_};
 
                 // Legalize search buffer for this search.
                 if (buffer.target() < num_neighbors) {
@@ -696,8 +694,7 @@ class MutableVamanaIndex {
             construction_window_size_,
             max_candidates_,
             prune_to_,
-            use_full_search_history_
-        };
+            use_full_search_history_};
 
         auto sp = get_search_parameters();
         auto prefetch_parameters =
@@ -710,8 +707,7 @@ class MutableVamanaIndex {
             threadpool_,
             prefetch_parameters,
             logger_,
-            logging::Level::Trace
-        };
+            logging::Level::Trace};
         builder.construct(alpha_, entry_point(), slots, logging::Level::Trace, logger_);
         // Mark all added entries as valid.
         for (const auto& i : slots) {
@@ -1013,8 +1009,7 @@ class MutableVamanaIndex {
                      get_max_candidates(),
                      prune_to_,
                      get_full_search_history()},
-                    get_search_parameters()
-                };
+                    get_search_parameters()};
 
                 return lib::SaveTable(
                     "vamana_dynamic_auxiliary_parameters",
@@ -1328,8 +1323,7 @@ struct VamanaStateLoader {
         if (debug_load_from_static) {
             return VamanaStateLoader{
                 lib::load<VamanaIndexParameters>(table),
-                IDTranslator::Identity(assume_datasize)
-            };
+                IDTranslator::Identity(assume_datasize)};
         }
 
         return VamanaStateLoader{
@@ -1430,8 +1424,7 @@ auto auto_dynamic_assemble(
         std::move(distance),
         std::move(translator),
         std::move(threadpool),
-        std::move(logger)
-    };
+        std::move(logger)};
 }
 
 } // namespace svs::index::vamana

--- a/include/svs/index/vamana/index.h
+++ b/include/svs/index/vamana/index.h
@@ -143,17 +143,13 @@ struct VamanaIndexParameters {
                 lib::load_at<size_t>(table, "construction_window_size"),
                 lib::load_at<size_t>(table, "max_candidates"),
                 prune_to,
-                use_full_search_history
-            },
+                use_full_search_history},
             VamanaSearchParameters{
                 SearchBufferConfig{
-                    lib::load_at<size_t>(table, "default_search_window_size")
-                },
+                    lib::load_at<size_t>(table, "default_search_window_size")},
                 lib::load_at<bool>(table, "visited_set"),
                 4,
-                1
-            }
-        };
+                1}};
     }
 
     static VamanaIndexParameters load(const lib::ContextFreeLoadTable& table) {
@@ -410,8 +406,7 @@ class VamanaIndex {
               entry_point,
               std::move(distance_function),
               std::move(threadpool),
-              logger
-          } {
+              logger} {
         if (graph_.n_nodes() != data_.size()) {
             throw ANNEXCEPTION("Wrong sizes!");
         }
@@ -455,8 +450,7 @@ class VamanaIndex {
                 sp.search_buffer_visited_set_
             ),
             extensions::single_search_setup(data_, distance_),
-            {sp.prefetch_lookahead_, sp.prefetch_step_}
-        };
+            {sp.prefetch_lookahead_, sp.prefetch_step_}};
     }
 
     /// @brief Return scratch-space resources for external threading with default parameters
@@ -574,12 +568,11 @@ class VamanaIndex {
                 auto search_buffer = search_buffer_type{
                     SearchBufferConfig(search_parameters.buffer_config_),
                     distance::comparator(distance_),
-                    search_parameters.search_buffer_visited_set_
-                };
+                    search_parameters.search_buffer_visited_set_};
 
                 auto prefetch_parameters = GreedySearchPrefetchParameters{
-                    search_parameters.prefetch_lookahead_, search_parameters.prefetch_step_
-                };
+                    search_parameters.prefetch_lookahead_,
+                    search_parameters.prefetch_step_};
 
                 // Increase the search window size if the defaults are not suitable for the
                 // requested number of neighbors.
@@ -809,8 +802,7 @@ class VamanaIndex {
     ) const {
         // Construct and save runtime parameters.
         auto parameters = VamanaIndexParameters{
-            entry_point_.front(), build_parameters_, get_search_parameters()
-        };
+            entry_point_.front(), build_parameters_, get_search_parameters()};
 
         // Config
         lib::save_to_disk(parameters, config_directory);
@@ -957,8 +949,7 @@ auto auto_build(
         lib::narrow<I>(entry_point),
         std::move(distance),
         std::move(threadpool),
-        logger
-    };
+        logger};
 }
 
 ///
@@ -1007,8 +998,7 @@ auto auto_assemble(
         I{},
         std::move(distance),
         std::move(threadpool),
-        std::move(logger)
-    };
+        std::move(logger)};
     auto config = lib::load_from_disk<VamanaIndexParameters>(config_path);
     index.apply(config);
     return index;

--- a/include/svs/index/vamana/vamana_build.h
+++ b/include/svs/index/vamana/vamana_build.h
@@ -124,11 +124,8 @@ template <typename Idx> class BackedgeBuffer {
         , bucket_locks_{parameters.num_buckets_} {}
 
     BackedgeBuffer(size_t num_elements, size_t bucket_size)
-        : BackedgeBuffer(
-              BackedgeBufferParameters{
-                  bucket_size, lib::div_round_up(num_elements, bucket_size)
-              }
-          ) {}
+        : BackedgeBuffer(BackedgeBufferParameters{
+              bucket_size, lib::div_round_up(num_elements, bucket_size)}) {}
 
     // Add a point.
     void add_edge(Idx src, Idx dst) {
@@ -339,7 +336,9 @@ class VamanaBuilder {
         update_type updates{threadpool_.size()};
         auto main = timer.push_back("main");
         threads::parallel_for(
-            threadpool_, range, [&](const auto& local_indices, uint64_t tid) {
+            threadpool_,
+            range,
+            [&](const auto& local_indices, uint64_t tid) {
                 // Thread local variables
                 auto& thread_local_updates = updates.at(tid);
 
@@ -490,7 +489,9 @@ class VamanaBuilder {
         auto range = threads::StaticPartition{indices};
         backedge_buffer_.reset();
         threads::parallel_for(
-            threadpool_, range, [&](const auto& is, uint64_t SVS_UNUSED(tid)) {
+            threadpool_,
+            range,
+            [&](const auto& is, uint64_t SVS_UNUSED(tid)) {
                 for (auto node_id : is) {
                     for (auto other_id : graph_.get_node(node_id)) {
                         std::lock_guard lock{vertex_locks_[other_id]};
@@ -539,8 +540,7 @@ class VamanaBuilder {
                                 i,
                                 distance::compute(
                                     general_distance, src_data, general_accessor(data_, i)
-                                )
-                            };
+                                )};
                         };
 
                         candidates.clear();

--- a/include/svs/lib/saveload/save.h
+++ b/include/svs/lib/saveload/save.h
@@ -198,7 +198,8 @@ concept HasZeroArgSaveTo = requires(const T& x) {
 ///
 /// The expected return type is either ``svs::lib::SaveTable`` or ``svs::lib::SaveNode``.
 ///
-/// This class is automatically defined for classes ``T`` with appropriate ``save()`` methods.
+/// This class is automatically defined for classes ``T`` with appropriate ``save()``
+/// methods.
 ///
 template <typename T> struct Saver {
     static SaveTable save(const T& x)

--- a/include/svs/lib/threads/types.h
+++ b/include/svs/lib/threads/types.h
@@ -435,11 +435,11 @@ DynamicPartition(const R&, size_t) -> DynamicPartition<typename R::const_iterato
 // Comment out the code until the issue is resolved in an upcoming fmt update
 // Related test: tests/svs/lib/threads/types.cpp::printing
 // Formatting
-//template <typename T>
-//struct fmt::formatter<svs::threads::UnitRange<T>> : svs::format_empty {
-    //auto format(const svs::threads::UnitRange<T>& x, auto& ctx) const {
-        //return fmt::format_to(
-            //ctx.out(), "UnitRange<{}>({}, {})", svs::datatype_v<T>, x.start(), x.stop()
-        //);
-    //}
+// template <typename T>
+// struct fmt::formatter<svs::threads::UnitRange<T>> : svs::format_empty {
+// auto format(const svs::threads::UnitRange<T>& x, auto& ctx) const {
+// return fmt::format_to(
+// ctx.out(), "UnitRange<{}>({}, {})", svs::datatype_v<T>, x.start(), x.stop()
+//);
+//}
 //};

--- a/include/svs/multi-arch/x86/preprocessor.h
+++ b/include/svs/multi-arch/x86/preprocessor.h
@@ -87,4 +87,3 @@
 
 #define DISTANCE_CS_EXTERN_TEMPLATE(N, AVX) \
     DISTANCE_CS_TEMPLATE_HELPER(extern template, N, AVX);
-

--- a/include/svs/quantization/scalar/scalar.h
+++ b/include/svs/quantization/scalar/scalar.h
@@ -578,8 +578,7 @@ class DecompressionAccessor {
         : decompressor_{data.get_scale(), data.get_bias()} {}
 
     // Access
-    template <IsSQData Data>
-    std::span<const float> operator()(const Data& data, size_t i) {
+    template <IsSQData Data> std::span<const float> operator()(const Data& data, size_t i) {
         return decompressor_(data.get_datum(i));
     }
 

--- a/include/svs/third-party/fmt.h
+++ b/include/svs/third-party/fmt.h
@@ -19,8 +19,8 @@
 // fmt
 #include "fmt/core.h"
 #include "fmt/format.h"
-#include "fmt/std.h"
 #include "fmt/ranges.h"
+#include "fmt/std.h"
 
 // stl
 #include <string_view>

--- a/tests/svs/index/inverted/clustering.cpp
+++ b/tests/svs/index/inverted/clustering.cpp
@@ -288,8 +288,7 @@ void test_end_to_end_clustering(
     });
 
     auto vamana_parameters = svs::index::vamana::VamanaBuildParameters{
-        construction_alpha, 64, 200, 1000, 60, true
-    };
+        construction_alpha, 64, 200, 1000, 60, true};
 
     // Build the index once and reuse it multiple times to help speed up tests.
     for (size_t max_replicas : {2, 8}) {

--- a/tests/svs/lib/threads/types.cpp
+++ b/tests/svs/lib/threads/types.cpp
@@ -200,10 +200,10 @@ CATCH_TEST_CASE("Thread Helper Types", "[core][threads]") {
             CATCH_REQUIRE(*(r.end() - 1) == 99);
         }
 
-        //CATCH_SECTION("Printing") {
-            //auto range = svs::threads::UnitRange<size_t>(100, 200);
-            //auto repr = fmt::format("{}", range);
-            //CATCH_REQUIRE(repr == "UnitRange<uint64>(100, 200)");
+        // CATCH_SECTION("Printing") {
+        // auto range = svs::threads::UnitRange<size_t>(100, 200);
+        // auto repr = fmt::format("{}", range);
+        // CATCH_REQUIRE(repr == "UnitRange<uint64>(100, 200)");
         //}
 
         CATCH_SECTION("Indexing") {

--- a/tests/svs/quantization/scalar/scalar.cpp
+++ b/tests/svs/quantization/scalar/scalar.cpp
@@ -15,11 +15,11 @@
  */
 
 // svs
-#include "svs/orchestrators/vamana.h"
 #include "svs/extensions/vamana/scalar.h"
-#include "svs/quantization/scalar/scalar.h"
 #include "svs/core/data/simple.h"
 #include "svs/lib/meta.h"
+#include "svs/orchestrators/vamana.h"
+#include "svs/quantization/scalar/scalar.h"
 
 #include "tests/svs/core/data/data.h"
 #include "tests/utils/generators.h"

--- a/tests/svs/quantization/scalar/scalar.cpp
+++ b/tests/svs/quantization/scalar/scalar.cpp
@@ -15,6 +15,8 @@
  */
 
 // svs
+#include "svs/orchestrators/vamana.h"
+#include "svs/extensions/vamana/scalar.h"
 #include "svs/quantization/scalar/scalar.h"
 #include "svs/core/data/simple.h"
 #include "svs/lib/meta.h"


### PR DESCRIPTION
During graph construction, both the query and dataset vectors are compressed. However, this compression was not handled correctly in the computation pipeline, leading to significantly reduced recall in some cases—especially when using normalized data with MIP (Maximum Inner Product) distance.