### PR TITLE
Increase tolerance for ground truth test

### DIFF
--- a/bindings/python/tests/test_common.py
+++ b/bindings/python/tests/test_common.py
@@ -215,12 +215,9 @@ class CommonTester(unittest.TestCase):
         k_smallest = np.argsort(dist_squared)[:, :k]
 
         # Some ties may not be resolved correctly, so provide some wiggle room.
-        # Older architectures with different distance implementations may resolve ties
+        # Architectures with different distance implementations may resolve ties
         # differently.
-        #
-        # Set max-ties to 6 to handle these older architectures as well (on newer
-        # architecture, it's generally 4).
-        max_ties = 6
+        max_ties = 8
         expected_equal_lower = groundtruth.size - max_ties
         actually_equal = np.count_nonzero(k_smallest == groundtruth)
 


### PR DESCRIPTION
We have seen test failures on new systems with the difference consistently 8.