### PR TITLE
Move OMP flag to optionally, manually defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,10 +77,6 @@ include("cmake/fmt.cmake")
 include("cmake/spdlog.cmake")
 include("cmake/toml.cmake")
 
-if(SVS_ENABLE_OMP)
-    include("cmake/openmp.cmake")
-endif()
-
 add_library(svs_x86_options_base INTERFACE)
 add_library(svs::x86_options_base ALIAS svs_x86_options_base)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -73,11 +73,6 @@ option(SVS_INITIALIZE_LOGGER
     ON # enabled by default
 )
 
-option(SVS_ENABLE_OMP
-    "Support OpenMP threadpool."
-    OFF # disable by default
-)
-
 #####
 ##### Experimental
 #####
@@ -143,12 +138,6 @@ if (SVS_INITIALIZE_LOGGER)
     target_compile_options(${SVS_LIB} INTERFACE -DSVS_INITIALIZE_LOGGER=1)
 else()
     target_compile_options(${SVS_LIB} INTERFACE -DSVS_INITIALIZE_LOGGER=0)
-endif()
-
-if (SVS_ENABLE_OMP)
-    target_compile_options(${SVS_LIB} INTERFACE -DSVS_ENABLE_OMP=1)
-else()
-    target_compile_options(${SVS_LIB} INTERFACE -DSVS_ENABLE_OMP=0)
 endif()
 
 #####

--- a/include/svs/lib/preprocessor.h
+++ b/include/svs/lib/preprocessor.h
@@ -106,6 +106,16 @@ consteval bool is_one_or_zero(const char* ptr) {
     }
 
 /////
+///// Optional flags
+/////
+#if defined(SVS_ENABLE_OMP)
+#define SVS_OMP 1
+#else
+#define SVS_OMP 0
+#endif
+
+
+/////
 ///// Intel(R) AVX extensions
 /////
 

--- a/include/svs/lib/threads/threadpool.h
+++ b/include/svs/lib/threads/threadpool.h
@@ -26,8 +26,8 @@
 #include <sstream>
 #include <vector>
 
-SVS_VALIDATE_BOOL_ENV(SVS_ENABLE_OMP);
-#if SVS_ENABLE_OMP
+SVS_VALIDATE_BOOL_ENV(SVS_OMP);
+#if SVS_OMP
 #include <omp.h>
 #endif
 
@@ -288,8 +288,8 @@ class SwitchNativeThreadPool {
     NativeThreadPool threadpool_;
 };
 
-SVS_VALIDATE_BOOL_ENV(SVS_ENABLE_OMP);
-#if SVS_ENABLE_OMP
+SVS_VALIDATE_BOOL_ENV(SVS_OMP);
+#if SVS_OMP
 /////
 ///// A thread pool that utilizes OpenMP for multithreading
 /////


### PR DESCRIPTION
In previous versions of SVS, the `SVS_ENABLE_OMP `flag was predefined as `OFF` in the SVS package. This PR allows users to manually configure the `SVS_ENABLE_OMP` flag in their CMake setup.