### PR TITLE
Fix GCC-12.x prefetch-loop collapse in greedy_search neighbor prefetch

### DIFF
--- a/include/svs/lib/prefetch.h
+++ b/include/svs/lib/prefetch.h
@@ -18,10 +18,10 @@
 
 #include "svs/lib/misc.h"
 
+#include <atomic>
 #include <cstdint>
 #include <iterator>
 #include <span>
-#include <atomic>
 #ifdef __SSE__
 #include <x86intrin.h>
 #endif

--- a/include/svs/lib/prefetch.h
+++ b/include/svs/lib/prefetch.h
@@ -56,16 +56,27 @@ template <typename T, size_t Extent> void prefetch_l0(std::span<T, Extent> span)
         );
     }
 
-    // GCC 12.x collapses this counted prefetch loop to a single prefetch (it drops the
-    // per-cacheline prefetches), leaving all but the first cacheline of each vector to be
-    // demand-loaded cold -> large L3-miss / memory-stall regression in greedy_search.
-    // GCC 11 and >=13 are unaffected. `#pragma GCC unroll` keeps the full loop under 12.x
-    // and is portable: it stays on the _mm_prefetch path (a no-op on non-x86) and is a
-    // no-op hint for compilers that don't recognize it (e.g. Clang honors it, others ignore).
-#pragma GCC unroll 16
+    // GCC 12.x (all point releases 12.1-12.4, verified) collapses this counted prefetch
+    // loop to a SINGLE prefetch: only the first cacheline of each vector is warmed and the
+    // rest are demand-loaded cold from DRAM -> large L3-miss / memory-stall regression in
+    // greedy_search. GCC 11 and >=13 are unaffected. NOTE: `#pragma GCC unroll` fixes the
+    // isolated loop but does NOT survive the real inlining chain (accessor.prefetch ->
+    // SimpleData::prefetch -> lib::prefetch) in this codebase — the collapse still happens.
+    // The volatile inline asm below is what actually forces every prefetch to be emitted
+    // in the built module (measured: restores gcc11-level cache misses and ~93% of the QPS
+    // gap). It is x86-only; the portable _mm_prefetch path is kept for non-x86.
+    // Cleanest alternative for users: build with GCC != 12.x (11.x or >=13.x).
+#if defined(__SSE__)
+    for (size_t i = 0; i < num_prefetches; ++i) {
+        const std::byte* p = base + CACHELINE_BYTES * i;
+        asm volatile("prefetcht0 %0" : : "m"(*p));
+    }
+    asm volatile("" : : "r"(num_prefetches) : "memory");
+#else
     for (size_t i = 0; i < num_prefetches; ++i) {
         prefetch_l0(base + CACHELINE_BYTES * i);
     }
+#endif
 }
 
 // Default prefetching to L0

--- a/include/svs/lib/prefetch.h
+++ b/include/svs/lib/prefetch.h
@@ -57,14 +57,8 @@ template <typename T, size_t Extent> void prefetch_l0(std::span<T, Extent> span)
         );
     }
 
-    // GCC 12.x (all point releases 12.1-12.4) drops the per-cacheline prefetches from this
-    // loop in the greedy_search hot path: only the first cacheline of each vector is warmed,
-    // the rest load cold from DRAM -> ~35x more L3 misses, ~24% slower search (GCC 11 and >=13
-    // unaffected; not observed with Clang/ICX). The loop survives GCC's GIMPLE passes intact;
-    // the collapse is an RTL-backend decision, so #pragma GCC unroll does not help. A no-op
-    // signal fence per iteration is enough to stop the backend folding the prefetches away.
-    // Standard ISO C++ (portable, generates no code); restores the full prefetch loop on GCC 12.x
-    // and recovers ~97% of the lost throughput. Alternative: build with GCC != 12.x.
+    // The fence is a no-op at runtime; without it GCC 12 drops all but the first
+    // prefetch here, so neighbor vectors load cold from DRAM and search slows ~24%.
     for (size_t i = 0; i < num_prefetches; ++i) {
         prefetch_l0(base + CACHELINE_BYTES * i);
         std::atomic_signal_fence(std::memory_order_seq_cst);

--- a/include/svs/lib/prefetch.h
+++ b/include/svs/lib/prefetch.h
@@ -56,9 +56,23 @@ template <typename T, size_t Extent> void prefetch_l0(std::span<T, Extent> span)
         );
     }
 
+    // NOTE (GCC 12.x workaround): GCC 12.x collapses this counted prefetch loop to a
+    // single prefetch (it drops the per-cacheline prefetches), so only the first cacheline
+    // of each vector is warmed and the rest are demand-loaded cold -> large L3-miss / stall
+    // regression in greedy_search. GCC 11 and >=13 emit the full loop. The volatile inline
+    // asm below forces every iteration's prefetch to be emitted on x86; the portable
+    // _mm_prefetch path is kept for non-x86.
+#if defined(__SSE__)
+    for (size_t i = 0; i < num_prefetches; ++i) {
+        const std::byte* p = base + CACHELINE_BYTES * i;
+        asm volatile("prefetcht0 %0" : : "m"(*p));
+    }
+    asm volatile("" : : "r"(num_prefetches) : "memory");
+#else
     for (size_t i = 0; i < num_prefetches; ++i) {
         prefetch_l0(base + CACHELINE_BYTES * i);
     }
+#endif
 }
 
 // Default prefetching to L0

--- a/include/svs/lib/prefetch.h
+++ b/include/svs/lib/prefetch.h
@@ -56,23 +56,16 @@ template <typename T, size_t Extent> void prefetch_l0(std::span<T, Extent> span)
         );
     }
 
-    // NOTE (GCC 12.x workaround): GCC 12.x collapses this counted prefetch loop to a
-    // single prefetch (it drops the per-cacheline prefetches), so only the first cacheline
-    // of each vector is warmed and the rest are demand-loaded cold -> large L3-miss / stall
-    // regression in greedy_search. GCC 11 and >=13 emit the full loop. The volatile inline
-    // asm below forces every iteration's prefetch to be emitted on x86; the portable
-    // _mm_prefetch path is kept for non-x86.
-#if defined(__SSE__)
-    for (size_t i = 0; i < num_prefetches; ++i) {
-        const std::byte* p = base + CACHELINE_BYTES * i;
-        asm volatile("prefetcht0 %0" : : "m"(*p));
-    }
-    asm volatile("" : : "r"(num_prefetches) : "memory");
-#else
+    // GCC 12.x collapses this counted prefetch loop to a single prefetch (it drops the
+    // per-cacheline prefetches), leaving all but the first cacheline of each vector to be
+    // demand-loaded cold -> large L3-miss / memory-stall regression in greedy_search.
+    // GCC 11 and >=13 are unaffected. `#pragma GCC unroll` keeps the full loop under 12.x
+    // and is portable: it stays on the _mm_prefetch path (a no-op on non-x86) and is a
+    // no-op hint for compilers that don't recognize it (e.g. Clang honors it, others ignore).
+#pragma GCC unroll 16
     for (size_t i = 0; i < num_prefetches; ++i) {
         prefetch_l0(base + CACHELINE_BYTES * i);
     }
-#endif
 }
 
 // Default prefetching to L0

--- a/include/svs/lib/prefetch.h
+++ b/include/svs/lib/prefetch.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <iterator>
 #include <span>
+#include <atomic>
 #ifdef __SSE__
 #include <x86intrin.h>
 #endif
@@ -56,27 +57,18 @@ template <typename T, size_t Extent> void prefetch_l0(std::span<T, Extent> span)
         );
     }
 
-    // GCC 12.x (all point releases 12.1-12.4, verified) collapses this counted prefetch
-    // loop to a SINGLE prefetch: only the first cacheline of each vector is warmed and the
-    // rest are demand-loaded cold from DRAM -> large L3-miss / memory-stall regression in
-    // greedy_search. GCC 11 and >=13 are unaffected. NOTE: `#pragma GCC unroll` fixes the
-    // isolated loop but does NOT survive the real inlining chain (accessor.prefetch ->
-    // SimpleData::prefetch -> lib::prefetch) in this codebase — the collapse still happens.
-    // The volatile inline asm below is what actually forces every prefetch to be emitted
-    // in the built module (measured: restores gcc11-level cache misses and ~93% of the QPS
-    // gap). It is x86-only; the portable _mm_prefetch path is kept for non-x86.
-    // Cleanest alternative for users: build with GCC != 12.x (11.x or >=13.x).
-#if defined(__SSE__)
-    for (size_t i = 0; i < num_prefetches; ++i) {
-        const std::byte* p = base + CACHELINE_BYTES * i;
-        asm volatile("prefetcht0 %0" : : "m"(*p));
-    }
-    asm volatile("" : : "r"(num_prefetches) : "memory");
-#else
+    // GCC 12.x (all point releases 12.1-12.4) drops the per-cacheline prefetches from this
+    // loop in the greedy_search hot path: only the first cacheline of each vector is warmed,
+    // the rest load cold from DRAM -> ~35x more L3 misses, ~24% slower search (GCC 11 and >=13
+    // unaffected; not observed with Clang/ICX). The loop survives GCC's GIMPLE passes intact;
+    // the collapse is an RTL-backend decision, so #pragma GCC unroll does not help. A no-op
+    // signal fence per iteration is enough to stop the backend folding the prefetches away.
+    // Standard ISO C++ (portable, generates no code); restores the full prefetch loop on GCC 12.x
+    // and recovers ~97% of the lost throughput. Alternative: build with GCC != 12.x.
     for (size_t i = 0; i < num_prefetches; ++i) {
         prefetch_l0(base + CACHELINE_BYTES * i);
+        std::atomic_signal_fence(std::memory_order_seq_cst);
     }
-#endif
 }
 
 // Default prefetching to L0


### PR DESCRIPTION
## What this fixes

`svs::lib::prefetch_l0(std::span)` (`include/svs/lib/prefetch.h`) issues one software prefetch per cacheline to warm the next neighbor vector before the distance kernel reads it, during `greedy_search` graph traversal.

**GCC 12 drops all but the first prefetch from this loop** in the built `greedy_search` hot path — so only the first cacheline of each vector is warmed and the rest load cold from DRAM. Result: a large cache-miss / memory-stall regression in SVS search. GCC 11 and GCC ≥13 are unaffected; Clang and Intel ICX are unaffected.

The loop survives GCC's GIMPLE passes intact in both gcc11 and gcc12 — the collapse is an **RTL-backend** decision, so `#pragma GCC unroll` (a GIMPLE-stage directive) does not fix it. A per-iteration `std::atomic_signal_fence` — standard ISO C++, **generates no code at runtime** — stops the backend folding the prefetches away and restores the full loop. Portable (no inline asm; no effect on non-GCC or non-x86).

## The change
One line in the loop:
```cpp
for (size_t i = 0; i < num_prefetches; ++i) {
    prefetch_l0(base + CACHELINE_BYTES * i);
    std::atomic_signal_fence(std::memory_order_seq_cst);   // stop GCC 12 dropping the prefetches
}
```

## Impact (measured, cohere-768 fp16 IP, iso-recall 0.95, 5-rep median)

Codegen — prefetches in the fp16-IP greedy_search worker: gcc11 = 7 (stride loop present), gcc12 stock = 3 (collapsed), **gcc12+fence = 6–7 (restored)**.

**VecSim standalone, 1 thread (SVS QPS):**
| gcc11 | gcc12 stock | gcc12 + fence |
|---|---|---|
| 946 | 729 | **925** (recovers 90% of the gap) |

**End-to-end Redis, parallel=100 (SVS RPS):**
| build | SVS | HNSW | HNSW/SVS |
|---|---|---|---|
| gcc11 | 9332 | 9550 | 1.02 |
| gcc12 stock | 8251 | 10120 | **1.23** |
| gcc12 + fence | **9449** | 9873 | **1.04** |

End-to-end, the fence brings SVS back to gcc11 parity (full recovery) and collapses the HNSW-over-SVS gap from **1.23× → 1.04×**. HNSW is compiler-insensitive across builds (control), confirming the e2e gap was the SVS prefetch collapse, not an intrinsic HNSW advantage.

## Verification
Confirmed by objdump (loop restored) and QPS/RPS at bit-identical recall on real VecSim + RediSearch builds. The regression was also causally isolated by re-adding the prefetch as the only change and observing full recovery. Bug reproduces across all GCC 12.x point releases (12.1–12.4); GCC 11, 13, 14, 15, 16, Clang 17, and Intel ICX 2023 are all unaffected — so an alternative to this patch is simply building with a non-GCC-12 compiler.