### PR TITLE
feat(vamana): Add replace_external_id, a data-preserving external-ID rename

### DIFF
--- a/include/svs/core/translation.h
+++ b/include/svs/core/translation.h
@@ -211,6 +211,36 @@ class IDTranslator {
     }
 
     ///
+    /// @brief Remap the external ID, keeping the same internal ID.
+    ///
+    /// @param from The existing external ID to rename.
+    /// @param to The external ID to rename it to.
+    /// @param check Check that ``from`` exists and ``to`` does not yet exist. Only safe
+    ///     to set to ``false`` if this holds true.
+    ///
+    /// Note, if ``check == true`` and either condition fails, the underlying translation
+    /// tables will not be modified.
+    ///
+    void remap_external_id(external_id_type from, external_id_type to, bool check = true) {
+        if (check) {
+            if (!has_external(from)) {
+                throw ANNEXCEPTION("Index does not contain external ID {}!", from);
+            }
+            if (has_external(to)) {
+                throw ANNEXCEPTION("Index already contains external ID {}!", to);
+            }
+        }
+
+        auto itr = external_to_internal_.find(from);
+        auto internal = itr->second;
+
+        // Updating the external-to-internal ID is easy.
+        internal_to_external_[internal] = to;
+        external_to_internal_.erase(itr);
+        external_to_internal_.insert({to, internal});
+    }
+
+    ///
     /// @brief Delete entries from internal IDs.
     ///
     /// @param internal_ids A container with the internal ids to delete. Must implement a

--- a/include/svs/index/vamana/dynamic_index.h
+++ b/include/svs/index/vamana/dynamic_index.h
@@ -463,6 +463,24 @@ class MutableVamanaIndex {
     }
 
     ///
+    /// @brief Rename external ID `old_id` to `new_id`, keeping the same stored vector
+    /// data and adjacency list.
+    ///
+    /// @param old_id The existing external ID to rename.
+    /// @param new_id The external ID to assign. Must not already exist.
+    ///
+    /// Requires that `old_id` exists in the index and `new_id` does not; throws
+    /// otherwise, leaving the index unmodified. Unlike `delete_entries` followed by
+    /// `add_points`, this is a pure bookkeeping operation on the ID translation table --
+    /// it does not touch the underlying dataset or graph.
+    ///
+    /// @see has_id, delete_entries
+    ///
+    void relabelVector(size_t old_id, size_t new_id) {
+        translator_.remap_external_id(old_id, new_id);
+    }
+
+    ///
     /// @brief Get the raw data for external id `e`.
     ///
     auto get_datum(size_t e) const { return data_.get_datum(translate_external_id(e)); }

--- a/include/svs/index/vamana/dynamic_index.h
+++ b/include/svs/index/vamana/dynamic_index.h
@@ -476,7 +476,7 @@ class MutableVamanaIndex {
     ///
     /// @see has_id, delete_entries
     ///
-    void relabelVector(size_t old_id, size_t new_id) {
+    void replace_external_id(size_t old_id, size_t new_id) {
         translator_.remap_external_id(old_id, new_id);
     }
 

--- a/include/svs/index/vamana/multi.h
+++ b/include/svs/index/vamana/multi.h
@@ -394,6 +394,37 @@ class MultiMutableVamanaIndex {
         return deletes.size();
     }
 
+    ///
+    /// @brief Rename label `old_label` to `new_label`, keeping every vector already
+    /// grouped under `old_label` -- and its placement in the parent index -- unchanged.
+    ///
+    /// @param old_label The existing label to rename.
+    /// @param new_label The label to assign. Must not already exist.
+    ///
+    /// Requires that `old_label` exists in the index and `new_label` does not; throws
+    /// otherwise, leaving the index unmodified. Pure bookkeeping on the label maps --
+    /// unlike `delete_entries` followed by `add_points`, it does not touch the
+    /// underlying dataset, graph, or per-vector external ids.
+    ///
+    /// @see has_id, delete_entries
+    ///
+    void replace_external_id(label_type old_label, label_type new_label) {
+        auto it = label_to_external_.find(old_label);
+        if (it == label_to_external_.end()) {
+            throw ANNEXCEPTION("Index does not contain label {}!", old_label);
+        }
+        if (label_to_external_.find(new_label) != label_to_external_.end()) {
+            throw ANNEXCEPTION("Index already contains label {}!", new_label);
+        }
+
+        auto externals = std::move(it->second);
+        label_to_external_.erase(it);
+        for (const auto& ext : externals) {
+            external_to_label_.at(ext) = new_label;
+        }
+        label_to_external_.insert({new_label, std::move(externals)});
+    }
+
     template <typename Query>
     void search(
         const Query& query,

--- a/tests/svs/core/translation.cpp
+++ b/tests/svs/core/translation.cpp
@@ -226,6 +226,42 @@ CATCH_TEST_CASE("Translation Table", "[core][translation]") {
         }
 
         ///
+        /// Renaming (relabeling)
+        ///
+
+        CATCH_SECTION("Rename External") {
+            translator.remap_external_id(2, 100);
+
+            CATCH_REQUIRE(!translator.has_external(2));
+            CATCH_REQUIRE(translator.has_external(100));
+            CATCH_REQUIRE(translator.get_internal(100) == 10);
+            CATCH_REQUIRE(translator.get_external(10) == 100);
+            CATCH_REQUIRE(translator.size() == external_ids.size());
+
+            // Everything else is unaffected.
+            CATCH_REQUIRE(translator.get_internal(0) == 0);
+            CATCH_REQUIRE(translator.get_internal(4) == 20);
+            CATCH_REQUIRE(translator.get_internal(6) == 30);
+            CATCH_REQUIRE(translator.get_internal(8) == 40);
+        }
+
+        CATCH_SECTION("Rename External Error - Source Does Not Exist") {
+            // External id `10` doesn't exist yet.
+            CATCH_REQUIRE_THROWS_AS(
+                translator.remap_external_id(10, 100), svs::ANNException
+            );
+            // State of the translator should be unchanged.
+            check(translator, external_ids, internal_ids);
+        }
+
+        CATCH_SECTION("Rename External Error - Destination Already Exists") {
+            // External id `4` already exists.
+            CATCH_REQUIRE_THROWS_AS(translator.remap_external_id(2, 4), svs::ANNException);
+            // State of the translator should be unchanged.
+            check(translator, external_ids, internal_ids);
+        }
+
+        ///
         /// Saving and loading
         ///
 

--- a/tests/svs/index/vamana/dynamic_index.cpp
+++ b/tests/svs/index/vamana/dynamic_index.cpp
@@ -19,6 +19,7 @@
 #include "svs/index/vamana/consolidate.h"
 
 // stl
+#include <algorithm>
 #include <cstdint>
 #include <filesystem>
 #include <iostream>
@@ -362,6 +363,61 @@ CATCH_TEST_CASE(
                 }
             }
         }
+    }
+}
+
+CATCH_TEST_CASE("MutableVamana Index Relabel", "[graph_index][dynamic_index]") {
+    const size_t num_threads = 2;
+    using Distance = svs::distance::DistanceL2;
+
+    auto data = test_dataset::data_blocked_f32();
+    std::vector<size_t> indices(data.size());
+    std::iota(indices.begin(), indices.end(), 0);
+
+    svs::index::vamana::VamanaBuildParameters parameters{1.2, 64, 10, 20, 10, true};
+    auto index = svs::index::vamana::MutableVamanaIndex(
+        parameters, std::move(data), indices, Distance(), num_threads
+    );
+
+    const size_t old_id = indices.front();
+    const size_t new_id = 999'999;
+    CATCH_REQUIRE(index.has_id(old_id));
+    CATCH_REQUIRE(!index.has_id(new_id));
+
+    auto internal_id_before = index.translate_external_id(old_id);
+    auto datum_before = index.get_datum(old_id);
+    auto datum_copy = std::vector<float>(datum_before.begin(), datum_before.end());
+    auto size_before = index.size();
+
+    index.relabelVector(old_id, new_id);
+
+    // The old label is gone, the new one exists, and nothing moved: same internal id,
+    // same stored data, same count -- this is a pure rename, not a delete + re-add.
+    CATCH_REQUIRE(!index.has_id(old_id));
+    CATCH_REQUIRE(index.has_id(new_id));
+    CATCH_REQUIRE(index.size() == size_before);
+    CATCH_REQUIRE(index.translate_external_id(new_id) == internal_id_before);
+    auto datum_after = index.get_datum(new_id);
+    CATCH_REQUIRE(std::equal(datum_after.begin(), datum_after.end(), datum_copy.begin()));
+
+    // Every other id is untouched.
+    for (size_t i = 1; i < indices.size(); ++i) {
+        CATCH_REQUIRE(index.has_id(indices[i]));
+    }
+
+    CATCH_SECTION("Renaming a non-existent ID throws") {
+        // `old_id` was already renamed away above, so it no longer exists either.
+        CATCH_REQUIRE_THROWS_AS(index.relabelVector(old_id, new_id + 1), svs::ANNException);
+        CATCH_REQUIRE(!index.has_id(old_id));
+        CATCH_REQUIRE(!index.has_id(new_id + 1));
+    }
+
+    CATCH_SECTION("Renaming onto an existing ID throws") {
+        auto other_id = indices[1];
+        CATCH_REQUIRE_THROWS_AS(index.relabelVector(new_id, other_id), svs::ANNException);
+        // State unchanged: the relabel performed above still holds.
+        CATCH_REQUIRE(index.has_id(new_id));
+        CATCH_REQUIRE(index.has_id(other_id));
     }
 }
 

--- a/tests/svs/index/vamana/dynamic_index.cpp
+++ b/tests/svs/index/vamana/dynamic_index.cpp
@@ -389,7 +389,7 @@ CATCH_TEST_CASE("MutableVamana Index Relabel", "[graph_index][dynamic_index]") {
     auto datum_copy = std::vector<float>(datum_before.begin(), datum_before.end());
     auto size_before = index.size();
 
-    index.relabelVector(old_id, new_id);
+    index.replace_external_id(old_id, new_id);
 
     // The old label is gone, the new one exists, and nothing moved: same internal id,
     // same stored data, same count -- this is a pure rename, not a delete + re-add.
@@ -407,14 +407,18 @@ CATCH_TEST_CASE("MutableVamana Index Relabel", "[graph_index][dynamic_index]") {
 
     CATCH_SECTION("Renaming a non-existent ID throws") {
         // `old_id` was already renamed away above, so it no longer exists either.
-        CATCH_REQUIRE_THROWS_AS(index.relabelVector(old_id, new_id + 1), svs::ANNException);
+        CATCH_REQUIRE_THROWS_AS(
+            index.replace_external_id(old_id, new_id + 1), svs::ANNException
+        );
         CATCH_REQUIRE(!index.has_id(old_id));
         CATCH_REQUIRE(!index.has_id(new_id + 1));
     }
 
     CATCH_SECTION("Renaming onto an existing ID throws") {
         auto other_id = indices[1];
-        CATCH_REQUIRE_THROWS_AS(index.relabelVector(new_id, other_id), svs::ANNException);
+        CATCH_REQUIRE_THROWS_AS(
+            index.replace_external_id(new_id, other_id), svs::ANNException
+        );
         // State unchanged: the relabel performed above still holds.
         CATCH_REQUIRE(index.has_id(new_id));
         CATCH_REQUIRE(index.has_id(other_id));

--- a/tests/svs/index/vamana/multi.cpp
+++ b/tests/svs/index/vamana/multi.cpp
@@ -449,3 +449,80 @@ CATCH_TEST_CASE(
         }
     }
 }
+
+CATCH_TEST_CASE("MultiMutableVamana Index Replace External ID", "[index][vamana][multi]") {
+    const size_t num_threads = 2;
+    using Distance = svs::distance::DistanceL2;
+
+    auto data = test_dataset::data_blocked_f32();
+    const size_t num_points = data.size();
+    std::vector<size_t> indices(num_points);
+    std::iota(indices.begin(), indices.end(), 0);
+
+    svs::index::vamana::VamanaBuildParameters parameters{1.2, 64, 10, 20, 10, true};
+    auto index = svs::index::vamana::MultiMutableVamanaIndex(
+        parameters, data, indices, Distance(), num_threads
+    );
+
+    // Shift by one and re-add: label 1 now groups two externals (its own original
+    // point and the re-added point 0), so the rename below has to move every external
+    // grouped under the label, not just the first.
+    std::vector<size_t> shifted(num_points);
+    std::iota(shifted.begin(), shifted.end(), 1);
+    index.add_points(data, shifted);
+
+    const size_t old_label = 1;
+    const size_t new_label = 999'999;
+    CATCH_REQUIRE(index.has_id(old_label));
+    CATCH_REQUIRE(!index.has_id(new_label));
+
+    auto externals_before = index.get_label_to_external_lookup().at(old_label);
+    CATCH_REQUIRE(externals_before.size() == 2);
+    auto size_before = index.size();
+    auto labelcount_before = index.labelcount();
+
+    index.replace_external_id(old_label, new_label);
+
+    // The old label is gone, the new one holds exactly the same externals, and
+    // nothing moved in the parent index or the dataset -- this is a pure rename, not
+    // a delete + re-add.
+    CATCH_REQUIRE(!index.has_id(old_label));
+    CATCH_REQUIRE(index.has_id(new_label));
+    CATCH_REQUIRE(index.size() == size_before);
+    CATCH_REQUIRE(index.labelcount() == labelcount_before);
+
+    auto externals_after = index.get_label_to_external_lookup().at(new_label);
+    CATCH_REQUIRE(
+        std::unordered_set<size_t>(externals_before.begin(), externals_before.end()) ==
+        std::unordered_set<size_t>(externals_after.begin(), externals_after.end())
+    );
+    for (auto ext : externals_after) {
+        CATCH_REQUIRE(index.get_external_to_label_lookup().at(ext) == new_label);
+    }
+
+    // Every other label is untouched.
+    for (size_t i = 0; i < num_points; ++i) {
+        if (i != old_label) {
+            CATCH_REQUIRE(index.has_id(i));
+        }
+    }
+
+    CATCH_SECTION("Renaming a non-existent label throws") {
+        // `old_label` was already renamed away above, so it no longer exists either.
+        CATCH_REQUIRE_THROWS_AS(
+            index.replace_external_id(old_label, new_label + 1), svs::ANNException
+        );
+        CATCH_REQUIRE(!index.has_id(old_label));
+        CATCH_REQUIRE(!index.has_id(new_label + 1));
+    }
+
+    CATCH_SECTION("Renaming onto an existing label throws") {
+        const size_t other_label = 2;
+        CATCH_REQUIRE_THROWS_AS(
+            index.replace_external_id(new_label, other_label), svs::ANNException
+        );
+        // State unchanged: the rename performed above still holds.
+        CATCH_REQUIRE(index.has_id(new_label));
+        CATCH_REQUIRE(index.has_id(other_label));
+    }
+}


### PR DESCRIPTION
## Summary

`MutableVamanaIndex::delete_entries` + `add_points` was the only existing way to change a
vector's external label -- and that path re-reads and re-inserts the vector's data, and
re-links its graph adjacency, even when the caller only wants a new label for data that
hasn't changed. That's exactly the situation a downstream index-update path faces after a
document update turns out not to have touched the vector: nothing about the stored vector or
its graph position needs to change, only the external ID it's known by.

- `IDTranslator::remap_external_id(from, to)`: the missing symmetric counterpart to the
  existing `remap_internal_id` (used internally by `compact()`) -- a pure O(1) hash-map key
  swap on the external ID, checked by default the same way `insert`/`delete_*` are.
- `MutableVamanaIndex::replace_external_id(old_id, new_id)`: exposes this at the index level,
  alongside the existing `translate_external_id`/`has_id`/`get_datum` methods it's meant to be
  used with. Touches neither the dataset nor the graph.
- `MultiMutableVamanaIndex::replace_external_id(old_label, new_label)`: the multi-value
  counterpart. Pure bookkeeping on `label_to_external_`/
  `external_to_label_` that moves every external id already grouped under `old_label` to
  `new_label` -- the plural case, since a multi-value label can hold more than one id where
  the single-value version only ever has one to move. Same "must exist / must not collide"
  exception semantics as the single-value version.

## Testing

- New "Rename External" section (plus two error-path sections) in
  `tests/svs/core/translation.cpp`.
- New "MutableVamana Index Relabel" test case in `tests/svs/index/vamana/dynamic_index.cpp`,
  verifying the internal id, stored data, and every other id are unaffected by the rename.
- New "MultiMutableVamana Index Replace External ID" test case in
  `tests/svs/index/vamana/multi.cpp`, built on a label with two externals grouped under it so
  the rename has more than one id to move, plus the same two error-path sections.
- Verified all error-path sections actually exercise their checks (not just happen to pass)
  by temporarily disabling each, confirming the throw-assertions fail as expected, then
  restoring it. Same for the multi-value rename itself: verified the new test fails when the
  `external_to_label_` update is skipped, before restoring the fix.